### PR TITLE
feat: add metadata scan and incremental reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. Dates use the ISO 8601 format (YYYY-MM-DD).
 
+## [1.1.1] - 2025-03-05
+### Added
+- Add metadata-first scanning with header previews, first-run context, and accessible modals.
+- Add settings controls to open scrippet files and copy their vault-relative paths.
+
+### Changed
+- Migrate script state tracking to stable scrippet ids with incremental reloads and lazy loading.
+- Append source URLs to evaluated scripts for clearer stack traces and runtime notices.
+
 ## [1.1.0] - 2025-09-22
 ### Added
 - Vault-based scrippet manager with metadata parsing, hot reload, and per-script enablement.
@@ -25,6 +34,7 @@ All notable changes to this project will be documented in this file. Dates use t
 ### Added
 - Initial release with basic command loading and startup script execution.
 
+[1.1.1]: https://github.com/josephcourtney/obsidian-scrippets/releases/tag/1.1.1
 [1.1.0]: https://github.com/josephcourtney/obsidian-scrippets/releases/tag/1.1.0
 [1.0.1]: https://github.com/josephcourtney/obsidian-scrippets/releases/tag/1.0.1
 [1.0.0]: https://github.com/josephcourtney/obsidian-scrippets/releases/tag/1.0.0

--- a/TODO.md
+++ b/TODO.md
@@ -1,29 +1,29 @@
 ### High priority
-- [ ] Migrate `scriptStates` keys from file path → stable scrippet id
+- [x] Migrate `scriptStates` keys from file path → stable scrippet id
   - Migrate existing path-based keys on load.
-- [ ] Implement metadata-only scan (no code evaluation)
+- [x] Implement metadata-only scan (no code evaluation)
   - Parse header, and cache metadata separately.
   - Surface runtime errors on first execution with clear notices.
-- [ ] Support incremental reload of only changed files on vault events
+- [x] Support incremental reload of only changed files on vault events
   - Reload only affected file(s) and update state.
   - Continue full reload when changes are complex (e.g., folder rename).
   - Batch changes and coalesce events for efficiency.
-- [ ] Append `//# sourceURL=<path>` to evaluated source for stack traces
+- [x] Append `//# sourceURL=<path>` to evaluated source for stack traces
   - Strip sensitive vault paths in favor of `<vault>/<relative-path>`.
-- [ ] Lazily `loadScrippet` on execution/enable
+- [x] Lazily `loadScrippet` on execution/enable
   - Load on first run only.
   - Cache instances per file until modify/rename.
   - Preload only enabled startup scripts.
-- [ ] Add "Open file" button in settings per scrippet
+- [x] Add "Open file" button in settings per scrippet
   - Open in new tab using Obsidian `app.workspace.openLinkText`.
-- [ ] Add "Copy path" button per scrippet
+- [x] Add "Copy path" button per scrippet
   - Copy vault-relative path.
-- [ ] Show file path, id, and header snippet in first-run confirmation modal
+- [x] Show file path, id, and header snippet in first-run confirmation modal
   - Limit snippet to first 10 lines and highlight directives.
-- [ ] Ensure modals trap focus and set ARIA labels
+- [x] Ensure modals trap focus and set ARIA labels
   - Use Obsidian’s built-in modal helpers.
-- [ ] Add `1.1.1` entry with date and changes to `CHANGELOG.md`
-- [ ] Verify `manifest.json`, `package.json`, `versions.json` versions stay aligned after release
+- [x] Add `1.1.1` entry with date and changes to `CHANGELOG.md`
+- [x] Verify `manifest.json`, `package.json`, `versions.json` versions stay aligned after release
 
 ### Medium priority
 - [ ] Add search/filter bar in settings scrippet list

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -32,6 +32,15 @@ export function parseScrippetMetadata(source: string): ParsedMetadata {
   return { metadata, source };
 }
 
+export function buildHeaderSnippet(source: string, maxLines = 10): string {
+  const lines = source.split(/\r?\n/).slice(0, maxLines);
+  if (lines.length === 0) return "";
+  return lines
+    .map((line) => escapeHtml(line))
+    .map((line) => line.replace(/(@[\w-]+)(\s*:\s*)/g, '<mark>$1</mark>$2'))
+    .join("<br>");
+}
+
 export function toDisplayName(filename: string, metadata: ScrippetMetadata): string {
   if (metadata.name) return metadata.name.trim();
   const base = getBasename(filename);
@@ -56,4 +65,13 @@ export function slugify(value: string): string {
     .trim()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }

--- a/src/scrippet-manager.ts
+++ b/src/scrippet-manager.ts
@@ -7,7 +7,12 @@ import {
   TFile,
   normalizePath,
 } from "obsidian";
-import { parseScrippetMetadata, toDisplayName, toIdentifier } from "./metadata";
+import {
+  buildHeaderSnippet,
+  parseScrippetMetadata,
+  toDisplayName,
+  toIdentifier,
+} from "./metadata";
 import { loadScrippet } from "./scrippet-loader";
 import { confirmFirstRun } from "./ui/confirm-run-modal";
 import type {
@@ -17,11 +22,27 @@ import type {
   ScrippetPluginSettings,
   ScrippetScanResult,
   ScrippetKind,
+  ScriptPreference,
 } from "./types";
 import { DEFAULT_SETTINGS } from "./types";
 
 const STARTUP_FOLDER = "startup";
 const COMMAND_PREFIX = "scrippet";
+
+interface PendingChanges {
+  changed: Set<string>;
+  deleted: Set<string>;
+  full: boolean;
+}
+
+function createPendingChanges(): PendingChanges {
+  return { changed: new Set(), deleted: new Set(), full: false };
+}
+
+interface QueuedChange {
+  type: "changed" | "deleted" | "full";
+  path?: string;
+}
 
 export interface ScrippetHost extends Plugin {
   app: App;
@@ -32,9 +53,15 @@ export interface ScrippetHost extends Plugin {
 export class ScrippetManager {
   private readonly plugin: ScrippetHost;
   private commands = new Map<string, string>();
-  private loaded = new Map<string, LoadedScrippet>();
+  private instanceCache = new Map<string, LoadedScrippet>();
+  private descriptorsByPath = new Map<string, ScrippetDescriptor>();
+  private descriptorsById = new Map<string, ScrippetDescriptor>();
   private listeners = new Set<() => void>();
   private reloadTimer: number | null = null;
+  private pendingChanges: PendingChanges = createPendingChanges();
+  private settingsDirty = false;
+  private errorMap = new Map<string, string>();
+  private skipped = new Set<string>();
   private lastScan: ScrippetScanResult = {
     commands: [],
     startup: [],
@@ -61,7 +88,7 @@ export class ScrippetManager {
 
   async initialize(): Promise<void> {
     await this.ensureFolders();
-    await this.reload({ runStartup: this.plugin.settings.runStartupOnLoad });
+    await this.performFullReload({ runStartup: this.plugin.settings.runStartupOnLoad });
     this.registerWatchers();
   }
 
@@ -71,45 +98,93 @@ export class ScrippetManager {
     this.plugin.settings.folder = normalized;
     await this.plugin.saveSettings();
     await this.ensureFolders();
-    await this.reload({ runStartup: this.plugin.settings.runStartupOnLoad });
+    await this.performFullReload({ runStartup: this.plugin.settings.runStartupOnLoad });
   }
 
   async reload(options: { runStartup?: boolean } = {}): Promise<void> {
-    const { runStartup = false } = options;
-    const result = await this.scanScrippets();
-    this.unregisterCommands();
-    this.loaded.clear();
-
-    this.lastScan = result;
-
-    for (const descriptor of result.commands) {
-      if (!descriptor.enabled) continue;
-      this.registerCommand(descriptor);
-    }
-
-    if (runStartup) {
-      await this.executeStartup(result.startup);
-    }
-
-    this.notify();
+    await this.performFullReload({ runStartup: options.runStartup ?? false });
   }
 
   async runStartupScripts(): Promise<void> {
     await this.executeStartup(this.lastScan.startup);
   }
 
-  async executeFromPath(path: string): Promise<void> {
-    const descriptor = this.loaded.get(path);
+  async executeById(id: string): Promise<void> {
+    const descriptor = this.descriptorsById.get(id);
     if (!descriptor) return;
     await this.executeDescriptor(descriptor);
   }
 
-  private async executeDescriptor(descriptor: LoadedScrippet): Promise<void> {
-    const key = this.preferenceKey(descriptor.path);
-    const prefs = (this.plugin.settings.scriptStates[key] ||= {
-      enabled: descriptor.enabled,
-      hasRun: false,
-    });
+  async toggleDescriptor(descriptor: ScrippetDescriptor, enabled: boolean): Promise<void> {
+    const prefs = this.ensurePreference(descriptor.id, descriptor.path);
+    prefs.enabled = enabled;
+    this.settingsDirty = true;
+    const record = this.descriptorsById.get(descriptor.id);
+    if (record) record.enabled = enabled;
+
+    if (descriptor.kind === "command") {
+      if (enabled) this.registerCommand(record ?? descriptor);
+      else this.unregisterCommand(descriptor.id);
+    }
+
+    this.updateLastScan();
+    this.notify();
+    await this.flushSettings();
+  }
+
+  private get baseFolder(): string {
+    return normalizePath(this.plugin.settings.folder || DEFAULT_SETTINGS.folder);
+  }
+
+  private get startupFolder(): string {
+    return normalizePath(`${this.baseFolder}/${STARTUP_FOLDER}`);
+  }
+
+  private async performFullReload(options: { runStartup: boolean }): Promise<void> {
+    this.unregisterCommands();
+    this.instanceCache.clear();
+    this.descriptorsByPath.clear();
+    this.descriptorsById.clear();
+    this.errorMap.clear();
+    this.skipped.clear();
+
+    const result = await this.scanScrippets();
+
+    for (const descriptor of result.commands) {
+      this.storeDescriptor(descriptor);
+    }
+    for (const descriptor of result.startup) {
+      this.storeDescriptor(descriptor);
+    }
+
+    this.errorMap.clear();
+    for (const error of result.errors) {
+      this.errorMap.set(error.path, error.message);
+    }
+    this.skipped = new Set(result.skipped);
+
+    this.updateLastScan();
+
+    for (const descriptor of this.lastScan.commands) {
+      if (descriptor.enabled) this.registerCommand(descriptor);
+    }
+
+    await this.flushSettings();
+    this.pendingChanges = createPendingChanges();
+    this.notify();
+
+    if (options.runStartup) {
+      await this.executeStartup(this.lastScan.startup);
+    }
+  }
+
+  private storeDescriptor(descriptor: ScrippetDescriptor): void {
+    this.descriptorsByPath.set(descriptor.path, descriptor);
+    this.descriptorsById.set(descriptor.id, descriptor);
+  }
+
+  private async executeDescriptor(descriptor: ScrippetDescriptor): Promise<void> {
+    const prefs = this.ensurePreference(descriptor.id, descriptor.path);
 
     if (!prefs.enabled) {
       new Notice(`Scrippet "${descriptor.name}" is disabled.`);
@@ -117,15 +192,27 @@ export class ScrippetManager {
     }
 
     if (this.plugin.settings.confirmBeforeFirstRun && !prefs.hasRun) {
-      const confirmed = await confirmFirstRun(this.plugin.app, descriptor.name);
+      const confirmed = await confirmFirstRun(this.plugin.app, descriptor);
       if (!confirmed) return;
     }
 
+    let loaded: LoadedScrippet;
     try {
-      await descriptor.instance.invoke(this.plugin);
+      loaded = await this.loadDescriptorInstance(descriptor);
+    } catch (error) {
+      this.recordLoadError(descriptor.path, error);
+      new Notice(
+        `Scrippet "${descriptor.name}" failed to load: ${(error as Error).message ?? String(error)}`,
+      );
+      return;
+    }
+
+    try {
+      await loaded.instance.invoke(this.plugin);
       if (!prefs.hasRun) {
         prefs.hasRun = true;
-        await this.plugin.saveSettings();
+        this.settingsDirty = true;
+        await this.flushSettings();
       }
     } catch (error) {
       console.error(`Scrippets: error invoking "${descriptor.name}"`, error);
@@ -133,35 +220,56 @@ export class ScrippetManager {
     }
   }
 
-  toggleDescriptor(descriptor: ScrippetDescriptor, enabled: boolean): void {
-    const key = this.preferenceKey(descriptor.path);
-    this.plugin.settings.scriptStates[key] = {
-      enabled,
-      hasRun: this.plugin.settings.scriptStates[key]?.hasRun ?? false,
-    };
-    descriptor.enabled = enabled;
-  }
+  private ensurePreference(id: string, path: string): ScriptPreference {
+    const scriptStates = this.plugin.settings.scriptStates;
+    const idKey = id;
+    const pathKey = normalizePath(path);
+    const existing = scriptStates[idKey];
+    if (existing) return existing;
 
-  private preferenceKey(path: string): string {
-    return normalizePath(path);
+    const legacy = scriptStates[pathKey];
+    if (legacy) {
+      delete scriptStates[pathKey];
+      scriptStates[idKey] = legacy;
+      this.settingsDirty = true;
+      return legacy;
+    }
+
+    const preference: ScriptPreference = {
+      enabled: true,
+      hasRun: false,
+    };
+    scriptStates[idKey] = preference;
+    this.settingsDirty = true;
+    return preference;
   }
 
   private async ensureFolders(): Promise<void> {
     const adapter = this.plugin.app.vault.adapter;
-    const base = normalizePath(this.plugin.settings.folder || DEFAULT_SETTINGS.folder);
-    await ensureFolder(adapter, base);
-    await ensureFolder(adapter, `${base}/${STARTUP_FOLDER}`);
+    await ensureFolder(adapter, this.baseFolder);
+    await ensureFolder(adapter, this.startupFolder);
   }
 
-  private registerCommand(descriptor: LoadedScrippet): void {
+  private registerCommand(descriptor: ScrippetDescriptor): void {
     const commandId = `${COMMAND_PREFIX}:${descriptor.id}`;
-    this.commands.set(descriptor.path, commandId);
-    this.loaded.set(descriptor.path, descriptor);
+    if (this.commands.has(descriptor.id)) {
+      this.plugin.removeCommand(this.commands.get(descriptor.id)!);
+    }
+    this.commands.set(descriptor.id, commandId);
     this.plugin.addCommand({
       id: commandId,
       name: descriptor.name,
-      callback: () => this.executeFromPath(descriptor.path),
+      callback: () => {
+        void this.executeById(descriptor.id);
+      },
     });
+  }
+
+  private unregisterCommand(id: string): void {
+    const commandId = this.commands.get(id);
+    if (!commandId) return;
+    this.plugin.removeCommand(commandId);
+    this.commands.delete(id);
   }
 
   private unregisterCommands(): void {
@@ -171,78 +279,104 @@ export class ScrippetManager {
     this.commands.clear();
   }
 
-  private async executeStartup(startup: LoadedScrippet[]): Promise<void> {
+  private async executeStartup(descriptors: ScrippetDescriptor[]): Promise<void> {
     let updated = false;
-    for (const descriptor of startup) {
-      const key = this.preferenceKey(descriptor.path);
-      const prefs = this.plugin.settings.scriptStates[key];
+    for (const descriptor of descriptors) {
+      const prefs = this.plugin.settings.scriptStates[descriptor.id];
       if (prefs && !prefs.enabled) continue;
       try {
-        await descriptor.instance.invoke(this.plugin);
+        const loaded = await this.loadDescriptorInstance(descriptor);
+        await loaded.instance.invoke(this.plugin);
         if (!prefs) {
-          this.plugin.settings.scriptStates[key] = {
+          this.plugin.settings.scriptStates[descriptor.id] = {
             enabled: true,
             hasRun: true,
           };
+          this.settingsDirty = true;
           updated = true;
         } else if (!prefs.hasRun) {
           prefs.hasRun = true;
+          this.settingsDirty = true;
           updated = true;
         }
       } catch (error) {
+        this.recordLoadError(descriptor.path, error);
         console.error(`Scrippets: startup scrippet failed for ${descriptor.name}`, error);
         new Notice(
-          `Startup scrippet "${descriptor.name}" failed: ${(error as Error).message ?? error}`,
+          `Startup scrippet "${descriptor.name}" failed: ${(error as Error).message ?? String(error)}`,
         );
       }
     }
     if (updated) {
-      await this.plugin.saveSettings();
+      await this.flushSettings();
     }
   }
 
-  private async scanScrippets(): Promise<ScrippetScanResult> {
-    const baseFolder = normalizePath(this.plugin.settings.folder || DEFAULT_SETTINGS.folder);
-    const startupFolder = normalizePath(`${baseFolder}/${STARTUP_FOLDER}`);
+  private async loadDescriptorInstance(descriptor: ScrippetDescriptor): Promise<LoadedScrippet> {
+    const cached = this.instanceCache.get(descriptor.id);
+    if (cached) return cached;
+    const adapter = this.plugin.app.vault.adapter;
+    const source = await adapter.read(descriptor.path);
+    const instance = loadScrippet(this.plugin, appendSourceUrl(source, descriptor.path));
+    const loaded: LoadedScrippet = {
+      ...descriptor,
+      instance,
+    };
+    this.instanceCache.set(descriptor.id, loaded);
+    this.errorMap.delete(descriptor.path);
+    this.updateLastScan();
+    this.notify();
+    return loaded;
+  }
 
-    const commandFiles = await this.listJsFiles(baseFolder, (path) => !isWithin(path, startupFolder));
-    const startupFiles = await this.listJsFiles(startupFolder);
+  private recordLoadError(path: string, error: unknown): void {
+    this.errorMap.set(path, (error as Error).message ?? String(error));
+    this.updateLastScan();
+    this.notify();
+  }
+
+  private async scanScrippets(): Promise<ScrippetScanResult> {
+    const commandFiles = await this.listJsFiles(this.baseFolder, (path) => !isWithin(path, this.startupFolder));
+    const startupFiles = await this.listJsFiles(this.startupFolder);
 
     const errors: ScrippetLoadError[] = [];
     const skipped: string[] = [];
-    const commandDescriptors: LoadedScrippet[] = [];
-    const startupDescriptors: LoadedScrippet[] = [];
+    const commandDescriptors: ScrippetDescriptor[] = [];
+    const startupDescriptors: ScrippetDescriptor[] = [];
     const processedIds = new Set<string>();
 
     await Promise.all(
       commandFiles.map(async (path) => {
-        const descriptor = await this.buildDescriptor(path, "command", processedIds, errors, skipped);
+        const descriptor = await this.tryBuildDescriptor(path, "command", processedIds, errors, skipped);
         if (descriptor) commandDescriptors.push(descriptor);
       }),
     );
 
     await Promise.all(
       startupFiles.map(async (path) => {
-        const descriptor = await this.buildDescriptor(path, "startup", processedIds, errors, skipped);
+        const descriptor = await this.tryBuildDescriptor(path, "startup", processedIds, errors, skipped);
         if (descriptor) startupDescriptors.push(descriptor);
       }),
     );
 
+    commandDescriptors.sort(sortByName);
+    startupDescriptors.sort(sortByName);
+
     return {
-      commands: commandDescriptors.sort(sortByName),
-      startup: startupDescriptors.sort(sortByName),
+      commands: commandDescriptors,
+      startup: startupDescriptors,
       errors,
       skipped,
     };
   }
 
-  private async buildDescriptor(
+  private async tryBuildDescriptor(
     path: string,
     kind: ScrippetKind,
     processedIds: Set<string>,
     errors: ScrippetLoadError[],
     skipped: string[],
-  ): Promise<LoadedScrippet | null> {
+  ): Promise<ScrippetDescriptor | null> {
     try {
       const adapter = this.plugin.app.vault.adapter;
       const src = await adapter.read(path);
@@ -261,22 +395,17 @@ export class ScrippetManager {
 
       const name = toDisplayName(path, metadata);
       const description = metadata.description ?? metadata.desc;
-      const key = this.preferenceKey(path);
-      const preference = (this.plugin.settings.scriptStates[key] ||= {
-        enabled: true,
-        hasRun: false,
-      });
-      const instance = loadScrippet(this.plugin, src);
-      const descriptor: LoadedScrippet = {
+      const preference = this.ensurePreference(id, path);
+
+      const descriptor: ScrippetDescriptor = {
         id,
         name,
         description,
         path,
         kind,
-        source: src,
         metadata,
         enabled: preference.enabled,
-        instance,
+        headerSnippet: buildHeaderSnippet(src),
       };
       return descriptor;
     } catch (error) {
@@ -302,38 +431,204 @@ export class ScrippetManager {
 
   private registerWatchers(): void {
     const vault = this.plugin.app.vault;
-    const onChange = () => this.scheduleReload();
-    this.plugin.registerEvent(vault.on("create", (file) => this.handleFileEvent(file, onChange)));
-    this.plugin.registerEvent(vault.on("modify", (file) => this.handleFileEvent(file, onChange)));
-    this.plugin.registerEvent(vault.on("delete", (file) => this.handleFileEvent(file, onChange)));
+    this.plugin.registerEvent(
+      vault.on("create", (file) => this.handleFileChange(file, "changed")),
+    );
+    this.plugin.registerEvent(
+      vault.on("modify", (file) => this.handleFileChange(file, "changed")),
+    );
+    this.plugin.registerEvent(
+      vault.on("delete", (file) => this.handleFileChange(file, "deleted")),
+    );
     this.plugin.registerEvent(
       vault.on("rename", (file, oldPath) => {
-        if (this.isManagedPath(oldPath) || this.isManagedPath(file.path)) onChange();
+        if (!(file instanceof TFile)) {
+          if (this.isManagedPath(oldPath) || this.isManagedPath(file.path)) {
+            this.queueChange({ type: "full" });
+          }
+          return;
+        }
+        if (this.isManagedPath(oldPath)) {
+          this.queueChange({ type: "deleted", path: oldPath });
+        }
+        if (this.isManagedPath(file.path)) {
+          this.queueChange({ type: "changed", path: file.path });
+        }
       }),
     );
   }
 
-  private handleFileEvent(file: TAbstractFile, onChange: () => void): void {
+  private handleFileChange(file: TAbstractFile, type: "changed" | "deleted"): void {
     if (!(file instanceof TFile)) return;
     if (!this.isManagedPath(file.path)) return;
-    onChange();
+    this.queueChange({ type, path: file.path });
   }
 
   private isManagedPath(path: string): boolean {
-    const base = normalizePath(this.plugin.settings.folder || DEFAULT_SETTINGS.folder);
-    const startup = normalizePath(`${base}/${STARTUP_FOLDER}`);
     const normalized = normalizePath(path);
-    return isWithin(normalized, base) || isWithin(normalized, startup);
+    return isWithin(normalized, this.baseFolder) || isWithin(normalized, this.startupFolder);
   }
 
-  private scheduleReload(): void {
-    if (this.reloadTimer != null) {
-      window.clearTimeout(this.reloadTimer);
+  private queueChange(change: QueuedChange): void {
+    this.registerChange(change);
+    if (this.reloadTimer == null) {
+      this.reloadTimer = window.setTimeout(() => {
+        this.reloadTimer = null;
+        void this.processPendingChanges();
+      }, 200);
     }
-    this.reloadTimer = window.setTimeout(() => {
-      this.reloadTimer = null;
-      void this.reload();
-    }, 200);
+  }
+
+  private registerChange(change: QueuedChange): void {
+    if (change.type === "full") {
+      this.pendingChanges.full = true;
+      this.pendingChanges.changed.clear();
+      this.pendingChanges.deleted.clear();
+      return;
+    }
+    if (this.pendingChanges.full) return;
+    if (!change.path) return;
+    const normalized = normalizePath(change.path);
+    if (change.type === "deleted") {
+      this.pendingChanges.deleted.add(normalized);
+      this.pendingChanges.changed.delete(normalized);
+    } else {
+      if (!this.pendingChanges.deleted.has(normalized)) {
+        this.pendingChanges.changed.add(normalized);
+      }
+    }
+  }
+
+  private async processPendingChanges(): Promise<void> {
+    const changes = this.pendingChanges;
+    this.pendingChanges = createPendingChanges();
+
+    if (changes.full) {
+      await this.performFullReload({ runStartup: false });
+      return;
+    }
+
+    const deletions = Array.from(changes.deleted);
+    const updates = Array.from(changes.changed);
+
+    for (const path of deletions) {
+      this.removeDescriptor(path);
+    }
+
+    for (const path of updates) {
+      await this.refreshDescriptor(path);
+    }
+
+    await this.flushSettings();
+    this.updateLastScan();
+    this.notify();
+  }
+
+  private removeDescriptor(path: string): void {
+    const normalized = normalizePath(path);
+    const descriptor = this.descriptorsByPath.get(normalized);
+    if (!descriptor) return;
+    this.descriptorsByPath.delete(normalized);
+    this.descriptorsById.delete(descriptor.id);
+    this.instanceCache.delete(descriptor.id);
+    this.unregisterCommand(descriptor.id);
+    this.errorMap.delete(normalized);
+    this.skipped.delete(normalized);
+  }
+
+  private async refreshDescriptor(path: string): Promise<void> {
+    const normalized = normalizePath(path);
+    if (!normalized.toLowerCase().endsWith(".js")) {
+      this.removeDescriptor(normalized);
+      return;
+    }
+
+    const kind = this.resolveKind(normalized);
+    if (!kind) {
+      this.removeDescriptor(normalized);
+      return;
+    }
+
+    const existing = this.descriptorsByPath.get(normalized);
+    try {
+      const descriptor = await this.createDescriptor(normalized, kind);
+      if (existing && existing.id !== descriptor.id) {
+        this.descriptorsById.delete(existing.id);
+        this.instanceCache.delete(existing.id);
+        this.unregisterCommand(existing.id);
+      }
+
+      const duplicate = this.descriptorsById.get(descriptor.id);
+      if (duplicate && duplicate.path !== normalized) {
+        this.descriptorsByPath.delete(normalized);
+        this.errorMap.set(normalized, `Duplicate scrippet id "${descriptor.id}"`);
+        this.skipped.add(normalized);
+        return;
+      }
+
+      this.descriptorsByPath.set(normalized, descriptor);
+      this.descriptorsById.set(descriptor.id, descriptor);
+      this.instanceCache.delete(descriptor.id);
+      this.errorMap.delete(normalized);
+      this.skipped.delete(normalized);
+
+      if (descriptor.kind === "command") {
+        if (descriptor.enabled) this.registerCommand(descriptor);
+        else this.unregisterCommand(descriptor.id);
+      }
+    } catch (error) {
+      this.descriptorsByPath.delete(normalized);
+      if (existing) {
+        this.descriptorsById.delete(existing.id);
+        this.instanceCache.delete(existing.id);
+        this.unregisterCommand(existing.id);
+      }
+      this.errorMap.set(normalized, (error as Error).message ?? String(error));
+    }
+  }
+
+  private resolveKind(path: string): ScrippetKind | null {
+    if (isWithin(path, this.startupFolder)) return "startup";
+    if (isWithin(path, this.baseFolder)) return "command";
+    return null;
+  }
+
+  private async createDescriptor(path: string, kind: ScrippetKind): Promise<ScrippetDescriptor> {
+    const adapter = this.plugin.app.vault.adapter;
+    const src = await adapter.read(path);
+    const { metadata } = parseScrippetMetadata(src);
+    const id = toIdentifier(path, metadata);
+    if (!id) throw new Error("Unable to derive scrippet id");
+    const name = toDisplayName(path, metadata);
+    const description = metadata.description ?? metadata.desc;
+    const preference = this.ensurePreference(id, path);
+    return {
+      id,
+      name,
+      description,
+      path,
+      kind,
+      metadata,
+      enabled: preference.enabled,
+      headerSnippet: buildHeaderSnippet(src),
+    };
+  }
+
+  private updateLastScan(): void {
+    const descriptors = Array.from(this.descriptorsByPath.values());
+    const commands = descriptors.filter((descriptor) => descriptor.kind === "command").sort(sortByName);
+    const startup = descriptors.filter((descriptor) => descriptor.kind === "startup").sort(sortByName);
+    const errors = Array.from(this.errorMap.entries())
+      .map(([path, message]) => ({ path, message }))
+      .sort((a, b) => a.path.localeCompare(b.path));
+    const skipped = Array.from(this.skipped.values()).sort();
+    this.lastScan = { commands, startup, errors, skipped };
+  }
+
+  private async flushSettings(): Promise<void> {
+    if (!this.settingsDirty) return;
+    this.settingsDirty = false;
+    await this.plugin.saveSettings();
   }
 }
 
@@ -355,4 +650,11 @@ function isWithin(path: string, folder: string): boolean {
 
 function sortByName(a: ScrippetDescriptor, b: ScrippetDescriptor): number {
   return a.name.localeCompare(b.name);
+}
+
+function appendSourceUrl(source: string, path: string): string {
+  const normalized = normalizePath(path);
+  const marker = "//# sourceURL=";
+  if (source.includes(marker)) return source;
+  return `${source}\n${marker}<vault>/${normalized}`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,9 +15,9 @@ export interface ScrippetDescriptor {
   description?: string;
   path: string;
   kind: ScrippetKind;
-  source: string;
   metadata: ScrippetMetadata;
   enabled: boolean;
+  headerSnippet: string;
 }
 
 export interface ScriptPreference {
@@ -55,8 +55,8 @@ export interface ScrippetLoadError {
 }
 
 export interface ScrippetScanResult {
-  commands: LoadedScrippet[];
-  startup: LoadedScrippet[];
+  commands: ScrippetDescriptor[];
+  startup: ScrippetDescriptor[];
   errors: ScrippetLoadError[];
   skipped: string[];
 }

--- a/src/ui/accessibility.ts
+++ b/src/ui/accessibility.ts
@@ -1,0 +1,65 @@
+import { Modal } from "obsidian";
+
+export interface ModalAccessibilityOptions {
+  initialFocus?: HTMLElement;
+  describedBy?: string;
+}
+
+export function applyModalAccessibility(
+  modal: Modal,
+  options: ModalAccessibilityOptions = {},
+): () => void {
+  const { modalEl, titleEl } = modal;
+  const existingId = titleEl.getAttr("id");
+  const titleId = existingId && existingId.length > 0 ? existingId : `scrippet-modal-title-${Date.now()}`;
+  titleEl.setAttr("id", titleId);
+
+  modalEl.setAttr("role", "dialog");
+  modalEl.setAttr("aria-modal", "true");
+  modalEl.setAttr("aria-labelledby", titleId);
+  if (options.describedBy) {
+    modalEl.setAttr("aria-describedby", options.describedBy);
+  }
+
+  const focusableSelector =
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+  const getFocusable = (): HTMLElement[] =>
+    Array.from(modalEl.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+      (element) => !element.hasAttribute("disabled"),
+    );
+
+  const focusFirst = () => {
+    const targets = getFocusable();
+    const initial = options.initialFocus ?? targets[0];
+    if (initial) {
+      initial.focus({ preventScroll: true });
+    }
+  };
+
+  const keyHandler = (event: KeyboardEvent) => {
+    if (event.key !== "Tab") return;
+    const elements = getFocusable();
+    if (elements.length === 0) return;
+    const first = elements[0]!;
+    const last = elements[elements.length - 1]!;
+    if (event.shiftKey) {
+      if (document.activeElement === first) {
+        event.preventDefault();
+        last.focus({ preventScroll: true });
+      }
+    } else if (document.activeElement === last) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+    }
+  };
+
+  modalEl.addEventListener("keydown", keyHandler);
+  window.setTimeout(focusFirst, 0);
+
+  return () => {
+    modalEl.removeEventListener("keydown", keyHandler);
+    if (options.describedBy) {
+      modalEl.removeAttribute("aria-describedby");
+    }
+  };
+}

--- a/styles.css
+++ b/styles.css
@@ -40,3 +40,34 @@
 .scrippet-confirm-modal .setting-item {
   justify-content: flex-end;
 }
+
+.scrippet-run-details {
+  margin-bottom: 8px;
+  font-size: var(--font-small);
+  color: var(--text-muted);
+}
+
+.scrippet-run-details p {
+  margin: 0;
+}
+
+.scrippet-snippet-wrapper {
+  margin: 8px 0 16px;
+  padding: 8px 10px;
+  background: var(--background-secondary);
+  border-radius: 4px;
+  max-height: 240px;
+  overflow: auto;
+}
+
+.scrippet-snippet {
+  margin: 0;
+  font-family: var(--font-monospace);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.scrippet-snippet mark {
+  background: var(--background-modifier-accent);
+  color: inherit;
+}


### PR DESCRIPTION
## Summary
- switch script state tracking to stable scrippet ids with metadata-first scans, lazy loading, and runtime error surfacing
- add incremental reload handling with cached instances, sourceURL tagging, and focus-trapped confirmation modals
- enhance settings actions with open/copy buttons, snippet previews, and document the 1.1.1 release

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d29e521fa883278830d0fbc26a8ed1