### PR TITLE
Add CSS snippet dependency metadata for scrippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. Dates use the ISO 8601 format (YYYY-MM-DD).
 
+## [Unreleased]
+### Added
+- Add `@requires-snippet` metadata so scrippets can declare CSS snippet file dependencies that are checked before invocation.
+
 ## [1.5.0] - 2026-08-03
 ### Added
 - Add bounded, session-local execution history with trigger, duration, status, and error details.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Obsidian Scrippets lets you author small JavaScript “scrippets” right inside
 
 - Works on desktop and mobile using the Obsidian vault adapter (no `fs` dependency).
 - Configurable scrippet folder under the vault config directory with live reload on file create, modify, rename, or delete.
-- Automatic metadata parsing from header comments for stable IDs, names, and descriptions.
+- Automatic metadata parsing from header comments for stable IDs, names, descriptions, and CSS snippet dependencies.
 - Per-scrippet enable/disable switches, first-run confirmation, and manual run buttons.
 - Startup folder support with explicit opt-in, per-file toggles, and one-time approval for untrusted startup scrippets.
 - Per-scrippet overlap protection while an invocation is still running.
@@ -24,7 +24,12 @@ Scrippets live in `/<vault>/<folder>/*.js`. By default, the folder is `<vault co
 Each file must expose an `invoke(plugin)` function. Three export shapes are supported:
 
 ```js
-/* @name: Toggle Wrap @id: toggle-wrap @desc: Toggle the nowrap snippet */
+/*
+ * @name: Toggle Wrap
+ * @id: toggle-wrap
+ * @desc: Toggle the nowrap snippet
+ * @requires-snippet: nowrap
+ */
 class Scrippet {
   async invoke(plugin) {
     const { app } = plugin;
@@ -62,6 +67,9 @@ An optional block comment at the top of the file can provide directives. Recogni
 - `@name` – display name in settings and the command palette
 - `@id` – stable identifier; otherwise derived from the filename
 - `@desc` – short description shown in settings
+- `@requires-snippet` – CSS snippet id that must exist in `<vault config dir>/snippets/` before the scrippet can run; use the snippet filename with or without the `.css` extension
+
+A required snippet only needs to exist. Its enabled/disabled state remains under the scrippet's control, which allows commands such as Toggle Wrap to enable and disable their own snippet. Missing dependencies fail through the normal execution error path and are included in recent execution history.
 
 Additional directives are ignored but preserved in the source.
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,7 @@ Scrippets live in `/<vault>/<folder>/*.js`. By default, the folder is `<vault co
 Each file must expose an `invoke(plugin)` function. Three export shapes are supported:
 
 ```js
-/*
- * @name: Toggle Wrap
- * @id: toggle-wrap
- * @desc: Toggle the nowrap snippet
- * @requires-snippet: nowrap
- */
+/* @name: Toggle Wrap @id: toggle-wrap @desc: Toggle the nowrap snippet @requires-snippet: nowrap */
 class Scrippet {
   async invoke(plugin) {
     const { app } = plugin;

--- a/examples/toggle_nowrap.js
+++ b/examples/toggle_nowrap.js
@@ -1,9 +1,4 @@
-/*
- * @name: Toggle Wrap
- * @id: toggle-wrap
- * @desc: Toggle the "nowrap" CSS snippet
- * @requires-snippet: nowrap
- */
+/* @name: Toggle Wrap @id: toggle-wrap @desc: Toggle the "nowrap" CSS snippet @requires-snippet: nowrap */
 class ToggleLineWrap {
   async invoke(plugin) {
     const { customCss } = plugin.app;

--- a/examples/toggle_nowrap.js
+++ b/examples/toggle_nowrap.js
@@ -1,4 +1,9 @@
-/* @name: Toggle Wrap @id: toggle-wrap @desc: Toggle the "nowrap" CSS snippet */
+/*
+ * @name: Toggle Wrap
+ * @id: toggle-wrap
+ * @desc: Toggle the "nowrap" CSS snippet
+ * @requires-snippet: nowrap
+ */
 class ToggleLineWrap {
   async invoke(plugin) {
     const { customCss } = plugin.app;

--- a/src/scrippet-loader.ts
+++ b/src/scrippet-loader.ts
@@ -1,14 +1,38 @@
-import { Notice, type Plugin } from "obsidian";
+import { Notice, normalizePath, type Plugin } from "obsidian";
+import { parseScrippetMetadata } from "./metadata";
+import { getRequiredSnippetId } from "./snippet-dependency";
 import { evaluateScrippetSource } from "./scrippet-runtime";
 import type { ScrippetModule } from "./types";
 
 export function loadScrippet(plugin: Plugin, source: string): ScrippetModule {
+  const { metadata } = parseScrippetMetadata(source);
+  const requiredSnippetId = getRequiredSnippetId(metadata);
   const mod = evaluateScrippetSource(plugin, plugin.app, Notice, source);
   const instance = typeof mod === "function" ? new (mod as new (plugin: Plugin) => unknown)(plugin) : mod;
   if (!isScrippetModule(instance)) {
     throw new Error("Scrippet must expose invoke(plugin)");
   }
-  return instance;
+  if (!requiredSnippetId) return instance;
+
+  return withSnippetDependency(instance, requiredSnippetId);
+}
+
+function withSnippetDependency(instance: ScrippetModule, snippetId: string): ScrippetModule {
+  return {
+    invoke: async (plugin) => {
+      const snippetPath = normalizePath(
+        `${plugin.app.vault.configDir}/snippets/${snippetId}.css`,
+      );
+      const exists = await plugin.app.vault.adapter.exists(snippetPath);
+      if (!exists) {
+        throw new Error(
+          `Required CSS snippet "${snippetId}" was not found at "${snippetPath}".`,
+        );
+      }
+
+      return instance.invoke(plugin);
+    },
+  };
 }
 
 function isScrippetModule(candidate: unknown): candidate is ScrippetModule {

--- a/src/snippet-dependency.ts
+++ b/src/snippet-dependency.ts
@@ -1,0 +1,23 @@
+import type { ScrippetMetadata } from "./types";
+
+export function getRequiredSnippetId(metadata: ScrippetMetadata): string | undefined {
+  const raw = metadata["requires-snippet"];
+  if (raw == null) return undefined;
+
+  let id = raw.trim();
+  if (!id) {
+    throw new Error('Metadata "requires-snippet" must name a CSS snippet.');
+  }
+
+  if (id.toLowerCase().endsWith(".css")) {
+    id = id.slice(0, -4).trim();
+  }
+
+  if (!id || id === "." || id === ".." || /[\\/]/.test(id)) {
+    throw new Error(
+      `Invalid CSS snippet id "${raw.trim()}". Use a snippet name, not a path.`,
+    );
+  }
+
+  return id;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface ScrippetMetadata {
   name?: string;
   desc?: string;
   description?: string;
+  "requires-snippet"?: string;
 }
 
 export type ScrippetKind = "command" | "startup";

--- a/tests/snippet-dependency.test.ts
+++ b/tests/snippet-dependency.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getRequiredSnippetId } from "../src/snippet-dependency.ts";
+
+test("returns undefined when no snippet dependency is declared", () => {
+  assert.equal(getRequiredSnippetId({}), undefined);
+});
+
+test("normalizes declared snippet ids", () => {
+  assert.equal(getRequiredSnippetId({ "requires-snippet": " nowrap " }), "nowrap");
+  assert.equal(getRequiredSnippetId({ "requires-snippet": "nowrap.css" }), "nowrap");
+});
+
+test("rejects empty snippet dependencies", () => {
+  assert.throws(
+    () => getRequiredSnippetId({ "requires-snippet": "   " }),
+    /must name a CSS snippet/,
+  );
+});
+
+test("rejects snippet paths", () => {
+  assert.throws(
+    () => getRequiredSnippetId({ "requires-snippet": "../nowrap" }),
+    /Use a snippet name, not a path/,
+  );
+  assert.throws(
+    () => getRequiredSnippetId({ "requires-snippet": "nested\\nowrap" }),
+    /Use a snippet name, not a path/,
+  );
+});


### PR DESCRIPTION
## Summary
- add `@requires-snippet` metadata for declaring a CSS snippet dependency
- validate the snippet id and check `<vault config dir>/snippets/<id>.css` on every invocation
- keep enabled/disabled state under the scrippet's control so toggle commands can manage their own snippet
- update the nowrap example, README, changelog, and add regression tests for dependency metadata parsing

## Behavior
A scrippet can declare:

```js
/* @name: Toggle Wrap @id: toggle-wrap @requires-snippet: nowrap */
```

If `nowrap.css` is missing from the vault's snippets folder, invocation fails through the existing execution error path and is recorded in recent execution history. If the file exists, the scrippet runs normally regardless of whether the CSS snippet is currently enabled.

## Validation
- Added unit coverage for missing, normalized, empty, and path-like snippet ids.
- Full `npm run check` / `npm run build` could not be executed in this environment because repository/package network access is unavailable.