### PR TITLE
Add configurable scrippet parameters and CSS bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file. Dates use t
 ## [Unreleased]
 ### Added
 - Add `@requires-snippet` metadata so scrippets can declare CSS snippet file dependencies that are checked before invocation.
+- Add typed per-scrippet parameters declared through YAML frontmatter, persisted by scrippet ID, rendered in the settings panel, and passed to `invoke(plugin, settings)`.
+- Add optional `css-var` bindings so parameter values can configure dependent CSS snippets through custom properties.
+
+### Changed
+- Extend the nowrap example with configurable cursor margin, fade width, and scrollbar clearance plus a matching CSS snippet example.
+
+### Fixed
+- Mask YAML frontmatter before JavaScript evaluation so frontmatter-based scrippets remain executable while preserving source line layout.
 
 ## [1.5.0] - 2026-08-03
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ Obsidian Scrippets lets you author small JavaScript “scrippets” right inside
 
 - Works on desktop and mobile using the Obsidian vault adapter (no `fs` dependency).
 - Configurable scrippet folder under the vault config directory with live reload on file create, modify, rename, or delete.
-- Automatic metadata parsing from header comments for stable IDs, names, descriptions, and CSS snippet dependencies.
-- Per-scrippet enable/disable switches, first-run confirmation, and manual run buttons.
+- Metadata from header comments or YAML frontmatter for stable IDs, names, descriptions, CSS snippet dependencies, and configurable parameters.
+- Per-scrippet enable/disable switches, first-run confirmation, manual run buttons, and persisted parameter values.
+- Typed parameter controls for booleans, numbers, strings, and select menus in the Scrippets settings panel.
+- Optional CSS custom-property bindings so parameters can configure dependent CSS snippets without rewriting snippet files.
 - Startup folder support with explicit opt-in, per-file toggles, and one-time approval for untrusted startup scrippets.
 - Per-scrippet overlap protection while an invocation is still running.
 - A bounded, session-local recent execution log with duration and failure details.
@@ -21,27 +23,22 @@ Scrippets execute with the same privileges as Obsidian. They can read, write, or
 
 Scrippets live in `/<vault>/<folder>/*.js`. By default, the folder is `<vault config dir>/scrippets/` (usually `.obsidian/scrippets/`). Startup scrippets go into the `startup/` sub-folder.
 
-Each file must expose an `invoke(plugin)` function. Three export shapes are supported:
+Each file must expose an `invoke(plugin)` or `invoke(plugin, settings)` function. Three export shapes are supported:
 
 ```js
-/* @name: Toggle Wrap @id: toggle-wrap @desc: Toggle the nowrap snippet @requires-snippet: nowrap */
+/* @name: Daily Notice @id: daily-notice */
 class Scrippet {
   async invoke(plugin) {
-    const { app } = plugin;
-    const snippets = app.customCss.enabledSnippets;
-    const enabled = snippets.has("nowrap");
-    app.customCss.setCssEnabledStatus("nowrap", !enabled);
+    new Notice("Remember to review your daily note!");
   }
 }
 ```
 
 ```js
-/* @name: Daily Notice @id: daily-notice */
-module.exports = class DailyNotice {
+/* @name: Exported Notice @id: exported-notice */
+module.exports = class ExportedNotice {
   async invoke(plugin) {
-    await plugin.app.workspace.onLayoutReady(() => {
-      new Notice("Remember to review your daily note!");
-    });
+    new Notice(`Running inside ${plugin.manifest.name}.`);
   }
 };
 ```
@@ -57,7 +54,7 @@ module.exports = { invoke };
 
 ### Metadata directives
 
-An optional block comment at the top of the file can provide directives. Recognised keys are:
+An optional block comment at the top of the file can provide simple directives:
 
 - `@name` – display name in settings and the command palette
 - `@id` – stable identifier; otherwise derived from the filename
@@ -66,7 +63,80 @@ An optional block comment at the top of the file can provide directives. Recogni
 
 A required snippet only needs to exist. Its enabled/disabled state remains under the scrippet's control, which allows commands such as Toggle Wrap to enable and disable their own snippet. Missing dependencies fail through the normal execution error path and are included in recent execution history.
 
-Additional directives are ignored but preserved in the source.
+The same metadata can be supplied through YAML frontmatter. Scrippets removes YAML frontmatter before evaluating the JavaScript while preserving its line layout for useful stack traces.
+
+### Configurable parameters
+
+Structured parameters are declared through YAML frontmatter under `settings`. Parameter values are stored by scrippet ID and passed as the second argument to `invoke`.
+
+```js
+---
+name: Example
+id: parameter-example
+settings:
+  enabled:
+    type: boolean
+    label: Enabled
+    default: true
+  margin:
+    type: number
+    label: Margin
+    description: Space around the feature.
+    default: 32
+    min: 0
+    max: 100
+    step: 1
+    unit: px
+  message:
+    type: string
+    label: Message
+    default: Hello
+  mode:
+    type: select
+    label: Mode
+    options:
+      compact: Compact
+      comfortable: Comfortable
+    default: comfortable
+---
+class Scrippet {
+  async invoke(plugin, settings) {
+    new Notice(`${settings.message} — ${settings.mode}`);
+  }
+}
+```
+
+Supported parameter types are `boolean`, `number`, `string`, and `select`. Number parameters may define `min`, `max`, `step`, and `unit`. Select options may be a YAML mapping as above or a list of strings / `{ value, label }` mappings. Saved values that no longer match the schema fall back to the declared default.
+
+The settings panel shows a **Scrippet parameters** section for every loaded scrippet that declares parameters. A **Reset** button removes saved overrides and returns that scrippet to its defaults.
+
+### Configuring CSS snippets with parameters
+
+A parameter can optionally bind to a CSS custom property with `css-var`. Scrippets keeps the property in sync with the saved parameter value and restores the previous inline value when the plugin unloads or the binding disappears.
+
+```yaml
+settings:
+  fade-width:
+    type: number
+    label: Edge fade width
+    default: 32
+    min: 0
+    max: 100
+    unit: px
+    css-var: --scrippets-nowrap-fade-width
+```
+
+The dependent CSS snippet can then use a fallback normally:
+
+```css
+.cm-editor::after {
+  width: var(--scrippets-nowrap-fade-width, 32px);
+}
+```
+
+For CSS-bound number parameters, `unit` is appended to the custom-property value. Boolean values are exposed as `1` or `0`; string and select values are passed through as text. When more than one loaded scrippet binds the same CSS variable, the scrippet with the later ID in lexical order wins, so unique names such as `--scrippets-<id>-...` are recommended.
+
+See `examples/toggle_nowrap.js` and `examples/nowrap.css` for a complete scrippet + snippet pair that exposes cursor margin, edge fade width, and scrollbar clearance through the settings panel.
 
 ### Startup scripts
 
@@ -79,6 +149,7 @@ Open **Settings → Community plugins → Scrippets** to:
 - Change the scrippet folder.
 - Toggle startup execution, confirm-first-run, and review safety warnings.
 - Inspect loaded commands, enable/disable them, and run them manually.
+- Configure parameters declared by scrippets and reset saved overrides.
 - View load errors or skipped files (e.g., duplicate IDs).
 - Add new files via the **+** dialog, including templates for the supported export shapes.
 - See whether a scrippet is currently running.
@@ -128,7 +199,9 @@ obsidian-scrippets/
 │   ├── main.ts         # Plugin entry
 │   ├── scrippet-manager.ts
 │   ├── metadata.ts
+│   ├── parameters.ts
 │   └── ui/             # Settings UI and modals
+├── examples/
 ├── esbuild.config.mjs
 ├── tsconfig.json
 ├── manifest.json
@@ -144,4 +217,3 @@ obsidian-scrippets/
 - [Obsidian API docs](https://docs.obsidian.md)
 - [Sample plugin](https://github.com/obsidianmd/obsidian-sample-plugin)
 - [Developer policies](https://docs.obsidian.md/Developer+policies)
-

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The settings panel shows a **Scrippet parameters** section for every loaded scri
 
 ### Configuring CSS snippets with parameters
 
-A parameter can optionally bind to a CSS custom property with `css-var`. Scrippets keeps the property in sync with the saved parameter value and restores the previous inline value when the plugin unloads or the binding disappears.
+A parameter can optionally bind to a CSS custom property with `css-var`. For safety, bound custom-property names must start with `--scrippets-`. Scrippets keeps the property in sync with the saved parameter value and restores the previous inline value when the plugin unloads or the binding disappears.
 
 ```yaml
 settings:
@@ -134,7 +134,7 @@ The dependent CSS snippet can then use a fallback normally:
 }
 ```
 
-For CSS-bound number parameters, `unit` is appended to the custom-property value. Boolean values are exposed as `1` or `0`; string and select values are passed through as text. When more than one loaded scrippet binds the same CSS variable, the scrippet with the later ID in lexical order wins, so unique names such as `--scrippets-<id>-...` are recommended.
+For CSS-bound number parameters, `unit` is appended to the custom-property value. Boolean values are exposed as `1` or `0`; string and select values are passed through as text. When more than one loaded scrippet binds the same CSS variable, the scrippet with the later ID in lexical order wins. The `--scrippets-` prefix is required, and names such as `--scrippets-<id>-...` are recommended to avoid collisions.
 
 See `examples/toggle_nowrap.js` and `examples/nowrap.css` for a complete scrippet + snippet pair that exposes cursor margin, edge fade width, and scrollbar clearance through the settings panel.
 

--- a/examples/nowrap.css
+++ b/examples/nowrap.css
@@ -1,0 +1,33 @@
+/* No wrap in editor (CM6) */
+.markdown-source-view.mod-cm6 .cm-content,
+.markdown-source-view.mod-cm6 .cm-line {
+  white-space: pre !important;
+  word-break: normal !important;
+}
+
+/* Disable wrapping for inline code in Live Preview */
+.markdown-source-view.mod-cm6 .cm-inline-code {
+  white-space: pre !important;
+}
+
+/* Leave enough room to scroll the end of a long line clear of the fade. */
+.markdown-source-view.mod-cm6 .cm-content {
+  padding-right: var(--scrippets-nowrap-fade-width, 32px) !important;
+}
+
+.markdown-source-view.mod-cm6 .cm-editor {
+  position: relative;
+}
+
+/* Fade long lines before they meet the vertical scrollbar. */
+.markdown-source-view.mod-cm6 .cm-editor::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: var(--scrippets-nowrap-scrollbar-offset, 12px);
+  bottom: 0;
+  width: var(--scrippets-nowrap-fade-width, 32px);
+  background: linear-gradient(to right, transparent, var(--background-primary));
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/toggle_nowrap.js
+++ b/examples/toggle_nowrap.js
@@ -1,11 +1,75 @@
-/* @name: Toggle Wrap @id: toggle-wrap @desc: Toggle the "nowrap" CSS snippet @requires-snippet: nowrap */
+---
+name: Toggle Wrap
+id: toggle-wrap
+description: Toggle editor line wrapping
+requires-snippet: nowrap
+settings:
+  cursor-margin:
+    type: number
+    label: Cursor scroll margin
+    description: Start horizontal scrolling before the caret reaches the right edge.
+    default: 48
+    min: 0
+    max: 200
+    step: 1
+    unit: px
+  fade-width:
+    type: number
+    label: Edge fade width
+    description: Width of the continuation fade at the right edge.
+    default: 32
+    min: 0
+    max: 100
+    step: 1
+    unit: px
+    css-var: --scrippets-nowrap-fade-width
+  scrollbar-offset:
+    type: number
+    label: Scrollbar clearance
+    description: Keep the fade clear of the vertical scrollbar.
+    default: 12
+    min: 0
+    max: 40
+    step: 1
+    unit: px
+    css-var: --scrippets-nowrap-scrollbar-offset
+---
 class ToggleLineWrap {
-  async invoke(plugin) {
-    const { customCss } = plugin.app;
+  async invoke(plugin, settings) {
+    const app = plugin.app;
+    const { customCss } = app;
     const snippetId = "nowrap";
     const enabled = customCss.enabledSnippets.has(snippetId);
-    customCss.setCssEnabledStatus(snippetId, !enabled);
-    new Notice(`${snippetId} ${enabled ? "disabled" : "enabled"}.`);
+    const nextEnabled = !enabled;
+
+    const key = "__toggleWrapEditorExtensions";
+    if (!plugin[key]) {
+      plugin[key] = [];
+      plugin.registerEditorExtension(plugin[key]);
+    }
+
+    const extensions = plugin[key];
+    extensions.length = 0;
+
+    if (nextEnabled) {
+      const cm = app.workspace.activeLeaf?.view?.editor?.cm;
+      const EditorView = cm?.constructor;
+      const cursorMargin = settings?.["cursor-margin"] ?? 48;
+
+      if (EditorView?.cursorScrollMargin) {
+        extensions.push(
+          EditorView.cursorScrollMargin.of({
+            x: cursorMargin,
+            y: 5,
+          }),
+        );
+      }
+    }
+
+    customCss.setCssEnabledStatus(snippetId, nextEnabled);
+    app.workspace.updateOptions();
+
+    new Notice(`${snippetId} ${nextEnabled ? "enabled" : "disabled"}.`);
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { Notice, Plugin, normalizePath } from "obsidian";
 import { ScrippetParameterCssRegistry } from "./parameter-css";
 import { ScrippetManager } from "./scrippet-manager";
 import { DEFAULT_SETTINGS, type ScrippetPluginSettings } from "./types";
-import { ScrippetSettingTab } from "./ui/settings-tab";
+import { ParameterizedScrippetSettingTab } from "./ui/parameter-settings-tab";
 
 export default class ScrippetPlugin extends Plugin {
   settings: ScrippetPluginSettings = DEFAULT_SETTINGS;
@@ -12,7 +12,7 @@ export default class ScrippetPlugin extends Plugin {
   async onload(): Promise<void> {
     await this.loadSettings();
     this.manager = new ScrippetManager(this);
-    this.addSettingTab(new ScrippetSettingTab(this.app, this));
+    this.addSettingTab(new ParameterizedScrippetSettingTab(this.app, this));
 
     this.app.workspace.onLayoutReady(() => {
       void this.initializeManager();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { Notice, Plugin, normalizePath } from "obsidian";
+import { ScrippetParameterCssRegistry } from "./parameter-css";
 import { ScrippetManager } from "./scrippet-manager";
 import { DEFAULT_SETTINGS, type ScrippetPluginSettings } from "./types";
 import { ScrippetSettingTab } from "./ui/settings-tab";
@@ -6,6 +7,7 @@ import { ScrippetSettingTab } from "./ui/settings-tab";
 export default class ScrippetPlugin extends Plugin {
   settings: ScrippetPluginSettings = DEFAULT_SETTINGS;
   manager!: ScrippetManager;
+  readonly parameterCss = new ScrippetParameterCssRegistry();
 
   async onload(): Promise<void> {
     await this.loadSettings();
@@ -18,6 +20,7 @@ export default class ScrippetPlugin extends Plugin {
   }
 
   onunload(): void {
+    this.parameterCss.clear();
     this.manager?.destroy();
   }
 
@@ -28,6 +31,7 @@ export default class ScrippetPlugin extends Plugin {
       ...DEFAULT_SETTINGS,
       folder: defaultFolder,
       ...(data ?? {}),
+      scrippetSettings: data?.scrippetSettings ?? {},
     };
   }
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,4 +1,5 @@
 import { normalizePath, parseYaml, stringifyYaml } from "obsidian";
+import { parseScrippetParameterSchema } from "./parameters";
 import type { ScrippetMetadata } from "./types";
 
 const METADATA_COMMENT = /\/\*([\s\S]*?)\*\//;
@@ -52,6 +53,14 @@ export function parseScrippetMetadata(source: string): ParsedMetadata {
   }
 
   return { metadata, source, frontmatter, comment };
+}
+
+export function maskScrippetFrontmatter(source: string, parsed: ParsedMetadata): string {
+  const frontmatter = parsed.frontmatter;
+  if (!frontmatter) return source;
+
+  const masked = frontmatter.raw.replace(/[^\r\n]/g, " ");
+  return source.slice(0, frontmatter.start) + masked + source.slice(frontmatter.end);
 }
 
 export function buildHeaderSnippet(source: string, maxLines = 10): string {
@@ -112,10 +121,16 @@ function safeParseYaml(raw: string): Record<string, unknown> | null {
 
 function applyMetadataRecord(target: ScrippetMetadata, record: Record<string, unknown>): void {
   for (const [key, rawValue] of Object.entries(record)) {
-    if (!isMetadataPrimitive(rawValue)) continue;
-    const value = String(rawValue);
     const normalized = key.trim().toLowerCase();
     if (!normalized) continue;
+
+    if (normalized === "settings") {
+      target.settings = parseScrippetParameterSchema(rawValue);
+      continue;
+    }
+
+    if (!isMetadataPrimitive(rawValue)) continue;
+    const value = String(rawValue);
     if (normalized === "description") target.description = value;
     else if (normalized === "desc") target.desc = value;
     else if (normalized === "name") target.name = value;

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -40,7 +40,7 @@ export function parseScrippetMetadata(source: string): ParsedMetadata {
         raw,
         data,
       };
-      applyMetadataRecord(metadata, data);
+      applyMetadataRecord(metadata, data, true);
     }
   }
 
@@ -119,13 +119,17 @@ function safeParseYaml(raw: string): Record<string, unknown> | null {
   return null;
 }
 
-function applyMetadataRecord(target: ScrippetMetadata, record: Record<string, unknown>): void {
+function applyMetadataRecord(
+  target: ScrippetMetadata,
+  record: Record<string, unknown>,
+  allowStructured = false,
+): void {
   for (const [key, rawValue] of Object.entries(record)) {
     const normalized = key.trim().toLowerCase();
     if (!normalized) continue;
 
     if (normalized === "settings") {
-      target.settings = parseScrippetParameterSchema(rawValue);
+      if (allowStructured) target.settings = parseScrippetParameterSchema(rawValue);
       continue;
     }
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -139,7 +139,7 @@ function applyMetadataRecord(
     else if (normalized === "desc") target.desc = value;
     else if (normalized === "name") target.name = value;
     else if (normalized === "id") target.id = value;
-    else target[normalized as keyof ScrippetMetadata] = value;
+    else target[normalized] = value;
   }
 }
 

--- a/src/parameter-css.ts
+++ b/src/parameter-css.ts
@@ -1,0 +1,74 @@
+import {
+  formatScrippetParameterCssValue,
+  resolveScrippetParameterValues,
+} from "./parameters";
+import type { ScrippetDescriptor, ScrippetParameterValues } from "./types";
+
+interface PreviousCssValue {
+  value: string;
+  priority: string;
+}
+
+export class ScrippetParameterCssRegistry {
+  private readonly previous = new Map<string, PreviousCssValue>();
+  private applied = new Set<string>();
+
+  sync(
+    descriptors: readonly ScrippetDescriptor[],
+    savedById: Record<string, ScrippetParameterValues>,
+  ): void {
+    const root = document.documentElement;
+    const next = new Map<string, string>();
+    const sorted = [...descriptors].sort((a, b) => a.id.localeCompare(b.id));
+
+    for (const descriptor of sorted) {
+      const schema = descriptor.metadata.settings;
+      if (!schema) continue;
+      const values = resolveScrippetParameterValues(schema, savedById[descriptor.id]);
+
+      for (const [key, definition] of Object.entries(schema)) {
+        if (!definition.cssVar) continue;
+        next.set(
+          definition.cssVar,
+          formatScrippetParameterCssValue(definition, values[key] ?? definition.default),
+        );
+      }
+    }
+
+    for (const name of this.applied) {
+      if (!next.has(name)) this.restore(root, name);
+    }
+
+    for (const [name, value] of next) {
+      if (!this.previous.has(name)) {
+        this.previous.set(name, {
+          value: root.style.getPropertyValue(name),
+          priority: root.style.getPropertyPriority(name),
+        });
+      }
+      root.style.setProperty(name, value);
+    }
+
+    this.applied = new Set(next.keys());
+  }
+
+  clear(): void {
+    const root = document.documentElement;
+    for (const name of [...this.applied]) {
+      this.restore(root, name);
+    }
+    this.applied.clear();
+    this.previous.clear();
+  }
+
+  private restore(root: HTMLElement, name: string): void {
+    const previous = this.previous.get(name);
+    if (previous?.value) {
+      root.style.setProperty(name, previous.value, previous.priority);
+    } else {
+      root.style.removeProperty(name);
+    }
+    this.previous.delete(name);
+    this.applied.delete(name);
+  }
+}

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -7,7 +7,7 @@ import type {
   ScrippetParameterValues,
 } from "./types";
 
-const CSS_CUSTOM_PROPERTY = /^--[A-Za-z0-9_-]+$/;
+const CSS_CUSTOM_PROPERTY = /^--scrippets-[A-Za-z0-9_-]+$/;
 const PARAMETER_TYPES = new Set<ScrippetParameterType>(["boolean", "number", "string", "select"]);
 
 export function parseScrippetParameterSchema(raw: unknown): ScrippetParameterSchema | undefined {
@@ -91,7 +91,7 @@ function parseDefinition(key: string, raw: unknown): ScrippetParameterDefinition
 
   if (cssVar && !CSS_CUSTOM_PROPERTY.test(cssVar)) {
     throw new Error(
-      `Scrippet setting "${key}" has invalid css-var "${cssVar}". CSS custom properties must start with --.`,
+      `Scrippet setting "${key}" has invalid css-var "${cssVar}". CSS custom properties must start with --scrippets-.`,
     );
   }
 

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -1,0 +1,279 @@
+import type {
+  ScrippetParameterDefinition,
+  ScrippetParameterOption,
+  ScrippetParameterSchema,
+  ScrippetParameterType,
+  ScrippetParameterValue,
+  ScrippetParameterValues,
+} from "./types";
+
+const CSS_CUSTOM_PROPERTY = /^--[A-Za-z0-9_-]+$/;
+const PARAMETER_TYPES = new Set<ScrippetParameterType>(["boolean", "number", "string", "select"]);
+
+export function parseScrippetParameterSchema(raw: unknown): ScrippetParameterSchema | undefined {
+  if (raw == null) return undefined;
+  if (!isRecord(raw)) {
+    throw new Error('Metadata "settings" must be a YAML mapping.');
+  }
+
+  const schema: ScrippetParameterSchema = {};
+  for (const [rawKey, rawDefinition] of Object.entries(raw)) {
+    const key = rawKey.trim();
+    if (!key) throw new Error("Scrippet setting names cannot be empty.");
+    schema[key] = parseDefinition(key, rawDefinition);
+  }
+
+  return Object.keys(schema).length > 0 ? schema : undefined;
+}
+
+export function resolveScrippetParameterValues(
+  schema: ScrippetParameterSchema | undefined,
+  saved: ScrippetParameterValues | undefined,
+): ScrippetParameterValues {
+  if (!schema) return {};
+
+  const resolved: ScrippetParameterValues = {};
+  for (const [key, definition] of Object.entries(schema)) {
+    const raw = saved?.[key];
+    if (raw === undefined) {
+      resolved[key] = definition.default;
+      continue;
+    }
+
+    try {
+      resolved[key] = coerceScrippetParameterValue(definition, raw);
+    } catch {
+      resolved[key] = definition.default;
+    }
+  }
+  return resolved;
+}
+
+export function coerceScrippetParameterValue(
+  definition: ScrippetParameterDefinition,
+  raw: unknown,
+): ScrippetParameterValue {
+  switch (definition.type) {
+    case "boolean":
+      return coerceBoolean(raw);
+    case "number":
+      return coerceNumber(definition, raw);
+    case "string":
+      if (typeof raw !== "string") throw new Error("Expected a string value.");
+      return raw;
+    case "select": {
+      if (typeof raw !== "string") throw new Error("Expected a select option value.");
+      const allowed = definition.options?.some((option) => option.value === raw) ?? false;
+      if (!allowed) throw new Error(`Unknown select option "${raw}".`);
+      return raw;
+    }
+  }
+}
+
+export function formatScrippetParameterCssValue(
+  definition: ScrippetParameterDefinition,
+  value: ScrippetParameterValue,
+): string {
+  if (definition.type === "boolean") return value ? "1" : "0";
+  if (definition.type === "number") return `${value}${definition.unit ?? ""}`;
+  return String(value);
+}
+
+function parseDefinition(key: string, raw: unknown): ScrippetParameterDefinition {
+  if (!isRecord(raw)) {
+    throw new Error(`Scrippet setting "${key}" must be a YAML mapping.`);
+  }
+
+  const type = parseType(key, raw.type);
+  const label = readOptionalString(raw.label) ?? humanize(key);
+  const description = readOptionalString(raw.description) ?? readOptionalString(raw.desc);
+  const cssVar = readOptionalString(raw["css-var"]) ?? readOptionalString(raw.cssVar);
+
+  if (cssVar && !CSS_CUSTOM_PROPERTY.test(cssVar)) {
+    throw new Error(
+      `Scrippet setting "${key}" has invalid css-var "${cssVar}". CSS custom properties must start with --.`,
+    );
+  }
+
+  const base: Omit<ScrippetParameterDefinition, "default"> = {
+    type,
+    label,
+    ...(description ? { description } : {}),
+    ...(cssVar ? { cssVar } : {}),
+  };
+
+  if (type === "number") {
+    const min = readOptionalFiniteNumber(raw.min, `${key}.min`);
+    const max = readOptionalFiniteNumber(raw.max, `${key}.max`);
+    const step = readOptionalFiniteNumber(raw.step, `${key}.step`);
+    const unit = readOptionalString(raw.unit);
+
+    if (min != null && max != null && min > max) {
+      throw new Error(`Scrippet setting "${key}" has min greater than max.`);
+    }
+    if (step != null && step <= 0) {
+      throw new Error(`Scrippet setting "${key}" must use a positive step.`);
+    }
+
+    const definition: ScrippetParameterDefinition = {
+      ...base,
+      type,
+      default: 0,
+      ...(min != null ? { min } : {}),
+      ...(max != null ? { max } : {}),
+      ...(step != null ? { step } : {}),
+      ...(unit ? { unit } : {}),
+    };
+
+    const fallback = min ?? 0;
+    const defaultValue = raw.default === undefined ? fallback : raw.default;
+    definition.default = coerceNumber(definition, defaultValue);
+    return definition;
+  }
+
+  if (raw.min !== undefined || raw.max !== undefined || raw.step !== undefined || raw.unit !== undefined) {
+    throw new Error(
+      `Scrippet setting "${key}" can only use min, max, step, or unit when type is number.`,
+    );
+  }
+
+  if (type === "boolean") {
+    return {
+      ...base,
+      type,
+      default: raw.default === undefined ? false : coerceBoolean(raw.default),
+    };
+  }
+
+  if (type === "string") {
+    if (raw.default !== undefined && typeof raw.default !== "string") {
+      throw new Error(`Scrippet setting "${key}" default must be a string.`);
+    }
+    return {
+      ...base,
+      type,
+      default: raw.default ?? "",
+    };
+  }
+
+  const options = parseOptions(key, raw.options);
+  const defaultValue = raw.default === undefined ? options[0]?.value : raw.default;
+  if (typeof defaultValue !== "string") {
+    throw new Error(`Scrippet setting "${key}" default must be a select option value.`);
+  }
+  if (!options.some((option) => option.value === defaultValue)) {
+    throw new Error(
+      `Scrippet setting "${key}" default "${defaultValue}" is not one of its options.`,
+    );
+  }
+
+  return {
+    ...base,
+    type,
+    default: defaultValue,
+    options,
+  };
+}
+
+function parseType(key: string, raw: unknown): ScrippetParameterType {
+  if (typeof raw !== "string" || !PARAMETER_TYPES.has(raw as ScrippetParameterType)) {
+    throw new Error(
+      `Scrippet setting "${key}" must declare type boolean, number, string, or select.`,
+    );
+  }
+  return raw as ScrippetParameterType;
+}
+
+function parseOptions(key: string, raw: unknown): ScrippetParameterOption[] {
+  const options: ScrippetParameterOption[] = [];
+
+  if (Array.isArray(raw)) {
+    for (const item of raw) {
+      if (typeof item === "string") {
+        options.push({ value: item, label: item });
+        continue;
+      }
+      if (!isRecord(item) || typeof item.value !== "string") {
+        throw new Error(
+          `Scrippet setting "${key}" options must be strings or { value, label } mappings.`,
+        );
+      }
+      options.push({
+        value: item.value,
+        label: readOptionalString(item.label) ?? item.value,
+      });
+    }
+  } else if (isRecord(raw)) {
+    for (const [value, label] of Object.entries(raw)) {
+      if (typeof label !== "string") {
+        throw new Error(`Scrippet setting "${key}" option labels must be strings.`);
+      }
+      options.push({ value, label });
+    }
+  } else {
+    throw new Error(`Scrippet setting "${key}" must declare select options.`);
+  }
+
+  if (options.length === 0) {
+    throw new Error(`Scrippet setting "${key}" must declare at least one select option.`);
+  }
+
+  const values = new Set<string>();
+  for (const option of options) {
+    if (!option.value) throw new Error(`Scrippet setting "${key}" has an empty option value.`);
+    if (values.has(option.value)) {
+      throw new Error(`Scrippet setting "${key}" has duplicate option "${option.value}".`);
+    }
+    values.add(option.value);
+  }
+
+  return options;
+}
+
+function coerceBoolean(raw: unknown): boolean {
+  if (typeof raw === "boolean") return raw;
+  if (raw === 1 || raw === "1" || raw === "true") return true;
+  if (raw === 0 || raw === "0" || raw === "false") return false;
+  throw new Error("Expected a boolean value.");
+}
+
+function coerceNumber(definition: ScrippetParameterDefinition, raw: unknown): number {
+  const value =
+    typeof raw === "number"
+      ? raw
+      : typeof raw === "string" && raw.trim() !== ""
+        ? Number(raw)
+        : Number.NaN;
+
+  if (!Number.isFinite(value)) throw new Error("Expected a finite number.");
+
+  let normalized = value;
+  if (definition.min != null) normalized = Math.max(definition.min, normalized);
+  if (definition.max != null) normalized = Math.min(definition.max, normalized);
+  return normalized;
+}
+
+function readOptionalString(raw: unknown): string | undefined {
+  if (raw == null) return undefined;
+  if (typeof raw !== "string") return undefined;
+  const value = raw.trim();
+  return value || undefined;
+}
+
+function readOptionalFiniteNumber(raw: unknown, path: string): number | undefined {
+  if (raw == null) return undefined;
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    throw new Error(`Scrippet setting "${path}" must be a finite number.`);
+  }
+  return raw;
+}
+
+function humanize(value: string): string {
+  return value
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/scrippet-loader.ts
+++ b/src/scrippet-loader.ts
@@ -1,38 +1,82 @@
 import { Notice, normalizePath, type Plugin } from "obsidian";
-import { parseScrippetMetadata } from "./metadata";
+import {
+  maskScrippetFrontmatter,
+  parseScrippetMetadata,
+  toIdentifier,
+} from "./metadata";
+import { resolveScrippetParameterValues } from "./parameters";
 import { getRequiredSnippetId } from "./snippet-dependency";
 import { evaluateScrippetSource } from "./scrippet-runtime";
-import type { ScrippetModule } from "./types";
+import type {
+  ScrippetMetadata,
+  ScrippetModule,
+  ScrippetParameterSchema,
+  ScrippetPluginSettings,
+} from "./types";
+
+interface ScrippetPluginHost extends Plugin {
+  settings?: Partial<ScrippetPluginSettings>;
+}
 
 export function loadScrippet(plugin: Plugin, source: string): ScrippetModule {
-  const { metadata } = parseScrippetMetadata(source);
+  const parsed = parseScrippetMetadata(source);
+  const { metadata } = parsed;
   const requiredSnippetId = getRequiredSnippetId(metadata);
-  const mod = evaluateScrippetSource(plugin, plugin.app, Notice, source);
+  const scrippetId = resolveScrippetId(source, metadata);
+  const executableSource = maskScrippetFrontmatter(source, parsed);
+  const mod = evaluateScrippetSource(plugin, plugin.app, Notice, executableSource);
   const instance = typeof mod === "function" ? new (mod as new (plugin: Plugin) => unknown)(plugin) : mod;
   if (!isScrippetModule(instance)) {
     throw new Error("Scrippet must expose invoke(plugin)");
   }
-  if (!requiredSnippetId) return instance;
+  if (!requiredSnippetId && !metadata.settings) return instance;
 
-  return withSnippetDependency(instance, requiredSnippetId);
+  return withScrippetFeatures(instance, requiredSnippetId, metadata.settings, scrippetId);
 }
 
-function withSnippetDependency(instance: ScrippetModule, snippetId: string): ScrippetModule {
+function withScrippetFeatures(
+  instance: ScrippetModule,
+  snippetId: string | undefined,
+  schema: ScrippetParameterSchema | undefined,
+  scrippetId: string | undefined,
+): ScrippetModule {
   return {
     invoke: async (plugin) => {
-      const snippetPath = normalizePath(
-        `${plugin.app.vault.configDir}/snippets/${snippetId}.css`,
-      );
-      const exists = await plugin.app.vault.adapter.exists(snippetPath);
-      if (!exists) {
-        throw new Error(
-          `Required CSS snippet "${snippetId}" was not found at "${snippetPath}".`,
+      if (snippetId) {
+        const snippetPath = normalizePath(
+          `${plugin.app.vault.configDir}/snippets/${snippetId}.css`,
         );
+        const exists = await plugin.app.vault.adapter.exists(snippetPath);
+        if (!exists) {
+          throw new Error(
+            `Required CSS snippet "${snippetId}" was not found at "${snippetPath}".`,
+          );
+        }
       }
 
-      return instance.invoke(plugin);
+      const settings = schema
+        ? resolveScrippetParameterValues(schema, getSavedSettings(plugin, scrippetId))
+        : undefined;
+      return instance.invoke(plugin, settings);
     },
   };
+}
+
+function getSavedSettings(plugin: Plugin, scrippetId: string | undefined) {
+  if (!scrippetId) return undefined;
+  const host = plugin as ScrippetPluginHost;
+  return host.settings?.scrippetSettings?.[scrippetId];
+}
+
+function resolveScrippetId(source: string, metadata: ScrippetMetadata): string | undefined {
+  if (metadata.id) return toIdentifier("", metadata);
+  const path = extractSourcePath(source);
+  return path ? toIdentifier(path, metadata) : undefined;
+}
+
+function extractSourcePath(source: string): string | undefined {
+  const match = /\/\/# sourceURL=<vault>\/([^\r\n]+)/.exec(source);
+  return match?.[1]?.trim() || undefined;
 }
 
 function isScrippetModule(candidate: unknown): candidate is ScrippetModule {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type ScrippetParameterSchema = Record<string, ScrippetParameterDefinition
 export type ScrippetParameterValues = Record<string, ScrippetParameterValue>;
 
 export interface ScrippetMetadata {
+  [key: string]: string | ScrippetParameterSchema | undefined;
   id?: string;
   name?: string;
   desc?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,36 @@
 import type { Plugin } from "obsidian";
 
+export type ScrippetParameterType = "boolean" | "number" | "string" | "select";
+export type ScrippetParameterValue = boolean | number | string;
+
+export interface ScrippetParameterOption {
+  value: string;
+  label: string;
+}
+
+export interface ScrippetParameterDefinition {
+  type: ScrippetParameterType;
+  label: string;
+  description?: string;
+  default: ScrippetParameterValue;
+  min?: number;
+  max?: number;
+  step?: number;
+  unit?: string;
+  options?: ScrippetParameterOption[];
+  cssVar?: string;
+}
+
+export type ScrippetParameterSchema = Record<string, ScrippetParameterDefinition>;
+export type ScrippetParameterValues = Record<string, ScrippetParameterValue>;
+
 export interface ScrippetMetadata {
   id?: string;
   name?: string;
   desc?: string;
   description?: string;
   "requires-snippet"?: string;
+  settings?: ScrippetParameterSchema;
 }
 
 export type ScrippetKind = "command" | "startup";
@@ -47,6 +72,7 @@ export interface ScrippetPluginSettings {
   runStartupOnLoad: boolean;
   confirmBeforeFirstRun: boolean;
   scriptStates: Record<string, ScriptPreference>;
+  scrippetSettings: Record<string, ScrippetParameterValues>;
   startupAcknowledged: boolean;
   allowedExtensions: string[];
   listSort: ScrippetListSort;
@@ -58,6 +84,7 @@ export const DEFAULT_SETTINGS: ScrippetPluginSettings = {
   runStartupOnLoad: false,
   confirmBeforeFirstRun: true,
   scriptStates: {},
+  scrippetSettings: {},
   startupAcknowledged: false,
   allowedExtensions: [".js", ".cjs"],
   listSort: { field: "name", direction: "asc" },
@@ -65,7 +92,10 @@ export const DEFAULT_SETTINGS: ScrippetPluginSettings = {
 };
 
 export interface ScrippetModule {
-  invoke: (plugin: Plugin) => void | Promise<unknown>;
+  invoke: (
+    plugin: Plugin,
+    settings?: Readonly<ScrippetParameterValues>,
+  ) => void | Promise<unknown>;
 }
 
 export interface LoadedScrippet extends ScrippetDescriptor {

--- a/src/ui/parameter-settings-tab.ts
+++ b/src/ui/parameter-settings-tab.ts
@@ -1,0 +1,183 @@
+import { App, Notice, Setting } from "obsidian";
+import type ScrippetPlugin from "../main";
+import {
+  coerceScrippetParameterValue,
+  resolveScrippetParameterValues,
+} from "../parameters";
+import type {
+  ScrippetDescriptor,
+  ScrippetParameterDefinition,
+  ScrippetParameterValue,
+} from "../types";
+import { ScrippetSettingTab } from "./settings-tab";
+
+export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
+  private readonly scrippetPlugin: ScrippetPlugin;
+
+  constructor(app: App, plugin: ScrippetPlugin) {
+    super(app, plugin);
+    this.scrippetPlugin = plugin;
+    this.scrippetPlugin.manager.subscribe(() => {
+      this.syncParameterCss();
+    });
+  }
+
+  override display(): void {
+    super.display();
+    this.syncParameterCss();
+    this.renderParameterSection();
+  }
+
+  private renderParameterSection(): void {
+    const descriptors = this.getParameterizedDescriptors();
+    if (descriptors.length === 0) return;
+
+    new Setting(this.containerEl)
+      .setName("Scrippet parameters")
+      .setDesc("Values are stored by scrippet ID and passed to invoke(plugin, settings).")
+      .setHeading();
+
+    const section = this.containerEl.createDiv({ cls: "scrippet-parameter-section" });
+    for (const descriptor of descriptors) {
+      this.renderScrippetParameters(section, descriptor);
+    }
+  }
+
+  private renderScrippetParameters(container: HTMLElement, descriptor: ScrippetDescriptor): void {
+    const schema = descriptor.metadata.settings;
+    if (!schema) return;
+
+    const card = container.createDiv({ cls: "scrippet-parameter-card" });
+    const header = new Setting(card).setName(descriptor.name);
+    const requiredSnippet = descriptor.metadata["requires-snippet"];
+    header.setDesc(
+      requiredSnippet
+        ? `ID: ${descriptor.id} · CSS snippet: ${requiredSnippet}`
+        : `ID: ${descriptor.id}`,
+    );
+
+    if (this.hasSavedValues(descriptor.id)) {
+      header.addButton((button) =>
+        button.setButtonText("Reset").setTooltip("Reset parameters to defaults").onClick(async () => {
+          delete this.scrippetPlugin.settings.scrippetSettings[descriptor.id];
+          await this.scrippetPlugin.saveSettings();
+          this.syncParameterCss();
+          this.redisplayPreservingScroll();
+        }),
+      );
+    }
+
+    const values = resolveScrippetParameterValues(
+      schema,
+      this.scrippetPlugin.settings.scrippetSettings[descriptor.id],
+    );
+
+    for (const [key, definition] of Object.entries(schema)) {
+      this.renderParameterControl(card, descriptor, key, definition, values[key] ?? definition.default);
+    }
+  }
+
+  private renderParameterControl(
+    container: HTMLElement,
+    descriptor: ScrippetDescriptor,
+    key: string,
+    definition: ScrippetParameterDefinition,
+    value: ScrippetParameterValue,
+  ): void {
+    const setting = new Setting(container).setName(definition.label);
+    if (definition.description) setting.setDesc(definition.description);
+
+    if (definition.type === "boolean") {
+      setting.addToggle((toggle) =>
+        toggle.setValue(Boolean(value)).onChange(async (next) => {
+          await this.saveParameterValue(descriptor, key, definition, next);
+        }),
+      );
+      return;
+    }
+
+    if (definition.type === "select") {
+      setting.addDropdown((dropdown) => {
+        for (const option of definition.options ?? []) {
+          dropdown.addOption(option.value, option.label);
+        }
+        dropdown.setValue(String(value)).onChange(async (next) => {
+          await this.saveParameterValue(descriptor, key, definition, next);
+        });
+      });
+      return;
+    }
+
+    setting.addText((text) => {
+      text.setValue(String(value));
+      if (definition.type === "number") {
+        text.inputEl.type = "number";
+        if (definition.min != null) text.inputEl.min = String(definition.min);
+        if (definition.max != null) text.inputEl.max = String(definition.max);
+        if (definition.step != null) text.inputEl.step = String(definition.step);
+      }
+      text.onChange(async (next) => {
+        if (definition.type === "number" && next.trim() === "") return;
+        try {
+          await this.saveParameterValue(descriptor, key, definition, next);
+          text.inputEl.removeClass("scrippet-parameter-invalid");
+        } catch (error) {
+          text.inputEl.addClass("scrippet-parameter-invalid");
+          console.debug(`Scrippets: invalid parameter ${descriptor.id}.${key}`, error);
+        }
+      });
+    });
+
+    if (definition.type === "number" && definition.unit) {
+      setting.controlEl.createSpan({ cls: "scrippet-parameter-unit", text: definition.unit });
+    }
+  }
+
+  private async saveParameterValue(
+    descriptor: ScrippetDescriptor,
+    key: string,
+    definition: ScrippetParameterDefinition,
+    raw: unknown,
+  ): Promise<void> {
+    const value = coerceScrippetParameterValue(definition, raw);
+    const current = this.scrippetPlugin.settings.scrippetSettings[descriptor.id] ?? {};
+    this.scrippetPlugin.settings.scrippetSettings[descriptor.id] = {
+      ...current,
+      [key]: value,
+    };
+
+    try {
+      await this.scrippetPlugin.saveSettings();
+      this.syncParameterCss();
+    } catch (error) {
+      console.error("Scrippets: failed to save parameter value", error);
+      new Notice("Failed to save scrippet parameter.");
+      throw error;
+    }
+  }
+
+  private getParameterizedDescriptors(): ScrippetDescriptor[] {
+    const { commands, startup } = this.scrippetPlugin.manager.scan;
+    return [...commands, ...startup]
+      .filter((descriptor) => Boolean(descriptor.metadata.settings))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  private hasSavedValues(id: string): boolean {
+    return Object.keys(this.scrippetPlugin.settings.scrippetSettings[id] ?? {}).length > 0;
+  }
+
+  private syncParameterCss(): void {
+    const { commands, startup } = this.scrippetPlugin.manager.scan;
+    this.scrippetPlugin.parameterCss.sync(
+      [...commands, ...startup],
+      this.scrippetPlugin.settings.scrippetSettings,
+    );
+  }
+
+  private redisplayPreservingScroll(): void {
+    const scrollTop = this.containerEl.scrollTop;
+    this.display();
+    this.containerEl.scrollTop = scrollTop;
+  }
+}

--- a/src/ui/parameter-settings-tab.ts
+++ b/src/ui/parameter-settings-tab.ts
@@ -120,9 +120,9 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
         if (definition.type === "number" && next.trim() === "") return;
         try {
           await this.saveParameterValue(descriptor, key, definition, next);
-          text.inputEl.removeClass("scrippet-parameter-invalid");
+          text.inputEl.classList.remove("scrippet-parameter-invalid");
         } catch (error) {
-          text.inputEl.addClass("scrippet-parameter-invalid");
+          text.inputEl.classList.add("scrippet-parameter-invalid");
           console.debug(`Scrippets: invalid parameter ${descriptor.id}.${key}`, error);
         }
       });

--- a/styles.css
+++ b/styles.css
@@ -153,10 +153,6 @@
   font-weight: var(--font-medium);
 }
 
-.scrippet-metadata-label {
-  font-weight: var(--font-medium);
-}
-
 .scrippet-execution-history {
   display: grid;
   gap: 6px;
@@ -194,4 +190,36 @@
   color: var(--text-error);
   font-size: var(--font-small);
   overflow-wrap: anywhere;
+}
+
+.scrippet-parameter-section {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.scrippet-parameter-card {
+  padding: 4px 12px;
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
+  border-radius: 8px;
+}
+
+.scrippet-parameter-card > .setting-item:first-child {
+  border-top: 0;
+}
+
+.scrippet-parameter-card .setting-item {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.scrippet-parameter-unit {
+  min-width: 2em;
+  color: var(--text-muted);
+  font-size: var(--font-small);
+}
+
+.scrippet-parameter-invalid {
+  border-color: var(--text-error) !important;
 }

--- a/tests/parameters.test.ts
+++ b/tests/parameters.test.ts
@@ -82,8 +82,8 @@ test("rejects invalid schemas", () => {
   assert.throws(
     () =>
       parseScrippetParameterSchema({
-        bad: { type: "number", "css-var": "not-a-custom-property" },
+        bad: { type: "number", "css-var": "--text-normal" },
       }),
-    /invalid css-var/,
+    /must start with --scrippets-/,
   );
 });

--- a/tests/parameters.test.ts
+++ b/tests/parameters.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  coerceScrippetParameterValue,
+  formatScrippetParameterCssValue,
+  parseScrippetParameterSchema,
+  resolveScrippetParameterValues,
+} from "../src/parameters.ts";
+
+test("parses supported parameter types and defaults", () => {
+  const schema = parseScrippetParameterSchema({
+    enabled: { type: "boolean", label: "Enabled", default: true },
+    margin: {
+      type: "number",
+      label: "Margin",
+      default: 48,
+      min: 0,
+      max: 200,
+      unit: "px",
+      "css-var": "--scrippets-margin",
+    },
+    title: { type: "string", default: "Example" },
+    mode: {
+      type: "select",
+      options: { compact: "Compact", comfortable: "Comfortable" },
+      default: "comfortable",
+    },
+  });
+
+  assert.ok(schema);
+  assert.equal(schema.enabled.default, true);
+  assert.equal(schema.margin.default, 48);
+  assert.equal(schema.margin.cssVar, "--scrippets-margin");
+  assert.equal(schema.title.label, "Title");
+  assert.deepEqual(schema.mode.options, [
+    { value: "compact", label: "Compact" },
+    { value: "comfortable", label: "Comfortable" },
+  ]);
+});
+
+test("resolves saved values and falls back from stale values", () => {
+  const schema = parseScrippetParameterSchema({
+    margin: { type: "number", default: 48, min: 0, max: 100 },
+    mode: { type: "select", options: ["compact", "comfortable"], default: "compact" },
+  });
+  assert.ok(schema);
+
+  assert.deepEqual(
+    resolveScrippetParameterValues(schema, {
+      margin: 500,
+      mode: "removed-option",
+    }),
+    {
+      margin: 100,
+      mode: "compact",
+    },
+  );
+});
+
+test("coerces UI values and formats CSS values", () => {
+  const schema = parseScrippetParameterSchema({
+    margin: { type: "number", default: 32, min: 0, max: 100, unit: "px" },
+    enabled: { type: "boolean" },
+  });
+  assert.ok(schema);
+
+  assert.equal(coerceScrippetParameterValue(schema.margin, "44"), 44);
+  assert.equal(coerceScrippetParameterValue(schema.enabled, "true"), true);
+  assert.equal(formatScrippetParameterCssValue(schema.margin, 44), "44px");
+  assert.equal(formatScrippetParameterCssValue(schema.enabled, false), "0");
+});
+
+test("rejects invalid schemas", () => {
+  assert.throws(
+    () => parseScrippetParameterSchema({ bad: { type: "number", min: 10, max: 5 } }),
+    /min greater than max/,
+  );
+  assert.throws(
+    () => parseScrippetParameterSchema({ bad: { type: "select", options: [] } }),
+    /at least one select option/,
+  );
+  assert.throws(
+    () =>
+      parseScrippetParameterSchema({
+        bad: { type: "number", "css-var": "not-a-custom-property" },
+      }),
+    /invalid css-var/,
+  );
+});


### PR DESCRIPTION
## Summary
- Add typed per-scrippet parameters declared through YAML frontmatter under `settings`.
- Persist overrides by stable scrippet ID and render boolean, number, string, and select controls in a new Scrippet parameters section.
- Pass resolved values to `invoke(plugin, settings)` while keeping existing one-argument scrippets compatible.
- Support number bounds, steps, units, stale-value fallback, and reset-to-default.
- Add optional `css-var` bindings for dependent snippets, restricted to the `--scrippets-` namespace and restored on plugin unload.
- Mask YAML frontmatter before JavaScript evaluation while preserving line layout.
- Parameterize the Toggle Wrap example with cursor margin, fade width, and scrollbar clearance, plus a matching `nowrap.css` example.
- Update README/CHANGELOG and add parameter-schema regression tests.

## Validation
- Added tests for parsing, defaults, stale-value fallback, coercion, CSS formatting, invalid schemas, and CSS-variable namespace enforcement.
- Performed strict TypeScript sanity checks of the parameter parser, metadata integration, invocation wrapper, CSS registry, and settings UI against minimal Obsidian API stubs; those checks passed.
- Full `npm run check` and `npm run build` could not be run in this environment because package/repository network access is unavailable.
- Manual Obsidian verification is still recommended for settings controls, live CSS-variable updates, persistence/reset behavior, and Toggle Wrap cursor scrolling.