### PR TITLE
Improve scrippet parameter controls and CSS variable defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ All notable changes to this project will be documented in this file. Dates use t
 - Add `@requires-snippet` metadata so scrippets can declare CSS snippet file dependencies that are checked before invocation.
 - Add typed per-scrippet parameters declared through `@settings` comment metadata or YAML frontmatter, persisted by scrippet ID, rendered in the settings panel, and passed to `invoke(plugin, settings)`.
 - Add optional `css-var` bindings so parameter values can configure dependent CSS snippets through custom properties.
+- Add slider controls for bounded numeric parameters with precise numeric inputs and `control: auto|slider|number` schema selection.
+- Add automatic CSS custom-property names with `css-var: true`, using `--scrippets-<scrippet-id>-<parameter-key>` by default.
 
 ### Changed
 - Extend the nowrap example with configurable cursor margin, fade width, and scrollbar clearance plus a matching CSS snippet example.
 - Prefer block-comment `@settings` metadata in JavaScript examples so scrippet files remain valid JavaScript for external tooling.
+- Show parameter defaults, resolved CSS custom-property names, and per-parameter reset actions in the settings panel.
 
 ### Fixed
 - Mask YAML frontmatter before JavaScript evaluation so frontmatter-based scrippets remain executable while preserving source line layout.
@@ -107,4 +110,3 @@ All notable changes to this project will be documented in this file. Dates use t
 [1.1.0]: https://github.com/josephcourtney/obsidian-scrippets/releases/tag/1.1.0
 [1.0.1]: https://github.com/josephcourtney/obsidian-scrippets/releases/tag/1.0.1
 [1.0.0]: https://github.com/josephcourtney/obsidian-scrippets/releases/tag/1.0.0
-

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Obsidian Scrippets lets you author small JavaScript “scrippets” right inside
 - Metadata from header comments or YAML frontmatter for stable IDs, names, descriptions, CSS snippet dependencies, and configurable parameters.
 - Per-scrippet enable/disable switches, first-run confirmation, manual run buttons, and persisted parameter values.
 - Typed parameter controls for booleans, numbers, strings, and select menus in the Scrippets settings panel.
-- Optional CSS custom-property bindings so parameters can configure dependent CSS snippets without rewriting snippet files.
+- Bounded numeric parameters use a slider plus precise number input by default, with schema overrides for slider-only intent or number-input intent.
+- Optional CSS custom-property bindings with automatic `--scrippets-<id>-<parameter>` names so parameters can configure dependent CSS snippets without rewriting snippet files.
 - Startup folder support with explicit opt-in, per-file toggles, and one-time approval for untrusted startup scrippets.
 - Per-scrippet overlap protection while an invocation is still running.
 - A bounded, session-local recent execution log with duration and failure details.
@@ -88,7 +89,9 @@ Structured parameters can be declared with `@settings` inside the metadata comme
     "min": 0,
     "max": 100,
     "step": 1,
-    "unit": "px"
+    "unit": "px",
+    "control": "slider",
+    "css-var": true
   },
   "message": {
     "type": "string",
@@ -113,17 +116,17 @@ class Scrippet {
 }
 ```
 
-Supported parameter types are `boolean`, `number`, `string`, and `select`. Number parameters may define `min`, `max`, `step`, and `unit`. Select options may be a mapping as above or a list of strings / `{ value, label }` mappings. Saved values that no longer match the schema fall back to the declared default.
+Supported parameter types are `boolean`, `number`, `string`, and `select`. Number parameters may define `min`, `max`, `step`, and `unit`. Bounded numbers with both `min` and `max` render as a slider plus a numeric input by default. Set `control` to `number` to suppress the slider, or `slider` to require a slider; explicit sliders must declare a usable `min` and `max`. `control: auto` is the default. Select options may be a mapping as above or a list of strings / `{ value, label }` mappings. Saved values that no longer match the schema fall back to the declared default.
 
 Structured `settings` metadata is also accepted through YAML frontmatter for compatibility, but comment metadata is recommended when the scrippet should remain standalone-valid JavaScript.
 
-The settings panel shows a **Scrippet parameters** section for every loaded scrippet that declares parameters. A **Reset** button removes saved overrides and returns that scrippet to its defaults.
+The settings panel shows a **Scrippet parameters** section for every loaded scrippet that declares parameters. Each parameter shows its default value, CSS custom-property name when applicable, and an individual reset action. A **Reset all** button removes every saved override for that scrippet.
 
 ### Configuring CSS snippets with parameters
 
-A parameter can optionally bind to a CSS custom property with `css-var`. For safety, bound custom-property names must start with `--scrippets-`. Scrippets keeps the property in sync with the saved parameter value and restores the previous inline value when the plugin unloads or the binding disappears.
+A parameter can optionally bind to a CSS custom property with `css-var`. Set `"css-var": true` to have Scrippets construct the name automatically as `--scrippets-<scrippet-id>-<parameter-key>`. The stable scrippet ID and parameter key determine the generated name, so changing a display label does not change the CSS API.
 
-For example, an `@settings` mapping can include:
+For example, with `@id: toggle-wrap`:
 
 ```json
 {
@@ -134,20 +137,26 @@ For example, an `@settings` mapping can include:
     "min": 0,
     "max": 100,
     "unit": "px",
-    "css-var": "--scrippets-nowrap-fade-width"
+    "css-var": true
   }
 }
 ```
 
-The dependent CSS snippet can then use a fallback normally:
+Scrippets exposes:
+
+```css
+--scrippets-toggle-wrap-fade-width: 32px;
+```
+
+The dependent CSS snippet can use a fallback normally:
 
 ```css
 .cm-editor::after {
-  width: var(--scrippets-nowrap-fade-width, 32px);
+  width: var(--scrippets-toggle-wrap-fade-width, 32px);
 }
 ```
 
-For CSS-bound number parameters, `unit` is appended to the custom-property value. Boolean values are exposed as `1` or `0`; string and select values are passed through as text. When more than one loaded scrippet binds the same CSS variable, the scrippet with the later ID in lexical order wins. The `--scrippets-` prefix is required, and names such as `--scrippets-<id>-...` are recommended to avoid collisions.
+If a different stable property name is needed, `css-var` may instead be an explicit `--scrippets-*` string. Omitting `css-var` (or setting it to `false`) keeps the parameter JavaScript-only. For CSS-bound number parameters, `unit` is appended to the custom-property value. Boolean values are exposed as `1` or `0`; string and select values are passed through as text. When more than one loaded scrippet binds the same CSS variable, the scrippet with the later ID in lexical order wins.
 
 See `examples/toggle_nowrap.js` and `examples/nowrap.css` for a complete scrippet + snippet pair that exposes cursor margin, edge fade width, and scrollbar clearance through the settings panel.
 
@@ -162,7 +171,7 @@ Open **Settings → Community plugins → Scrippets** to:
 - Change the scrippet folder.
 - Toggle startup execution, confirm-first-run, and review safety warnings.
 - Inspect loaded commands, enable/disable them, and run them manually.
-- Configure parameters declared by scrippets and reset saved overrides.
+- Configure parameters declared by scrippets with sliders, precise inputs, generated CSS-variable details, and reset actions.
 - View load errors or skipped files (e.g., duplicate IDs).
 - Add new files via the **+** dialog, including templates for the supported export shapes.
 - See whether a scrippet is currently running.

--- a/examples/nowrap.css
+++ b/examples/nowrap.css
@@ -12,7 +12,7 @@
 
 /* Leave enough room to scroll the end of a long line clear of the fade. */
 .markdown-source-view.mod-cm6 .cm-content {
-  padding-right: var(--scrippets-nowrap-fade-width, 32px) !important;
+  padding-right: var(--scrippets-toggle-wrap-fade-width, 32px) !important;
 }
 
 .markdown-source-view.mod-cm6 .cm-editor {
@@ -24,9 +24,9 @@
   content: "";
   position: absolute;
   top: 0;
-  right: var(--scrippets-nowrap-scrollbar-offset, 12px);
+  right: var(--scrippets-toggle-wrap-scrollbar-offset, 12px);
   bottom: 0;
-  width: var(--scrippets-nowrap-fade-width, 32px);
+  width: var(--scrippets-toggle-wrap-fade-width, 32px);
   background: linear-gradient(to right, transparent, var(--background-primary));
   pointer-events: none;
   z-index: 10;

--- a/examples/toggle_nowrap.js
+++ b/examples/toggle_nowrap.js
@@ -12,7 +12,8 @@
     "min": 0,
     "max": 200,
     "step": 1,
-    "unit": "px"
+    "unit": "px",
+    "control": "slider"
   },
   "fade-width": {
     "type": "number",
@@ -23,7 +24,8 @@
     "max": 100,
     "step": 1,
     "unit": "px",
-    "css-var": "--scrippets-nowrap-fade-width"
+    "control": "slider",
+    "css-var": true
   },
   "scrollbar-offset": {
     "type": "number",
@@ -34,7 +36,8 @@
     "max": 40,
     "step": 1,
     "unit": "px",
-    "css-var": "--scrippets-nowrap-scrollbar-offset"
+    "control": "slider",
+    "css-var": true
   }
 }
 */

--- a/src/parameter-css.ts
+++ b/src/parameter-css.ts
@@ -1,5 +1,6 @@
 import {
   formatScrippetParameterCssValue,
+  resolveScrippetParameterCssVarName,
   resolveScrippetParameterValues,
 } from "./parameters";
 import type { ScrippetDescriptor, ScrippetParameterValues } from "./types";
@@ -27,9 +28,10 @@ export class ScrippetParameterCssRegistry {
       const values = resolveScrippetParameterValues(schema, savedById[descriptor.id]);
 
       for (const [key, definition] of Object.entries(schema)) {
-        if (!definition.cssVar) continue;
+        const name = resolveScrippetParameterCssVarName(descriptor.id, key, definition);
+        if (!name) continue;
         next.set(
-          definition.cssVar,
+          name,
           formatScrippetParameterCssValue(definition, values[key] ?? definition.default),
         );
       }

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -1,4 +1,5 @@
 import type {
+  ScrippetParameterControl,
   ScrippetParameterDefinition,
   ScrippetParameterOption,
   ScrippetParameterSchema,
@@ -9,11 +10,12 @@ import type {
 
 const CSS_CUSTOM_PROPERTY = /^--scrippets-[A-Za-z0-9_-]+$/;
 const PARAMETER_TYPES = new Set<ScrippetParameterType>(["boolean", "number", "string", "select"]);
+const PARAMETER_CONTROLS = new Set<ScrippetParameterControl>(["auto", "slider", "number"]);
 
 export function parseScrippetParameterSchema(raw: unknown): ScrippetParameterSchema | undefined {
   if (raw == null) return undefined;
   if (!isRecord(raw)) {
-    throw new Error('Metadata "settings" must be a YAML mapping.');
+    throw new Error('Metadata "settings" must be a mapping/object.');
   }
 
   const schema: ScrippetParameterSchema = {};
@@ -79,21 +81,44 @@ export function formatScrippetParameterCssValue(
   return String(value);
 }
 
+export function resolveScrippetParameterCssVarName(
+  scrippetId: string,
+  key: string,
+  definition: ScrippetParameterDefinition,
+): string | undefined {
+  if (!definition.cssVar) return undefined;
+  if (definition.cssVar !== true) return definition.cssVar;
+
+  const idPart = toCssNamePart(scrippetId);
+  const keyPart = toCssNamePart(key);
+  if (!idPart || !keyPart) return undefined;
+  return `--scrippets-${idPart}-${keyPart}`;
+}
+
+export function shouldUseScrippetParameterSlider(
+  definition: ScrippetParameterDefinition,
+): boolean {
+  if (definition.type !== "number" || definition.control === "number") return false;
+  const bounded =
+    definition.min != null &&
+    definition.max != null &&
+    Number.isFinite(definition.min) &&
+    Number.isFinite(definition.max) &&
+    definition.max > definition.min;
+  if (!bounded) return false;
+  return definition.control === "slider" || definition.control == null || definition.control === "auto";
+}
+
 function parseDefinition(key: string, raw: unknown): ScrippetParameterDefinition {
   if (!isRecord(raw)) {
-    throw new Error(`Scrippet setting "${key}" must be a YAML mapping.`);
+    throw new Error(`Scrippet setting "${key}" must be a mapping/object.`);
   }
 
   const type = parseType(key, raw.type);
   const label = readOptionalString(raw.label) ?? humanize(key);
   const description = readOptionalString(raw.description) ?? readOptionalString(raw.desc);
-  const cssVar = readOptionalString(raw["css-var"]) ?? readOptionalString(raw.cssVar);
-
-  if (cssVar && !CSS_CUSTOM_PROPERTY.test(cssVar)) {
-    throw new Error(
-      `Scrippet setting "${key}" has invalid css-var "${cssVar}". CSS custom properties must start with --scrippets-.`,
-    );
-  }
+  const cssVar = parseCssVar(key, raw["css-var"] ?? raw.cssVar);
+  const control = parseControl(key, type, raw.control);
 
   const base: Omit<ScrippetParameterDefinition, "default"> = {
     type,
@@ -114,10 +139,16 @@ function parseDefinition(key: string, raw: unknown): ScrippetParameterDefinition
     if (step != null && step <= 0) {
       throw new Error(`Scrippet setting "${key}" must use a positive step.`);
     }
+    if (control === "slider" && (min == null || max == null || max <= min)) {
+      throw new Error(
+        `Scrippet setting "${key}" uses a slider and must declare min and max with max greater than min.`,
+      );
+    }
 
     const definition: ScrippetParameterDefinition = {
       ...base,
       type,
+      control,
       default: 0,
       ...(min != null ? { min } : {}),
       ...(max != null ? { max } : {}),
@@ -182,6 +213,46 @@ function parseType(key: string, raw: unknown): ScrippetParameterType {
     );
   }
   return raw as ScrippetParameterType;
+}
+
+function parseControl(
+  key: string,
+  type: ScrippetParameterType,
+  raw: unknown,
+): ScrippetParameterControl {
+  if (raw == null) return "auto";
+  if (type !== "number") {
+    throw new Error(`Scrippet setting "${key}" can only use control when type is number.`);
+  }
+  if (typeof raw !== "string" || !PARAMETER_CONTROLS.has(raw as ScrippetParameterControl)) {
+    throw new Error(`Scrippet setting "${key}" control must be auto, slider, or number.`);
+  }
+  return raw as ScrippetParameterControl;
+}
+
+function parseCssVar(key: string, raw: unknown): true | string | undefined {
+  if (raw == null || raw === false) return undefined;
+  if (raw === true) {
+    if (!toCssNamePart(key)) {
+      throw new Error(
+        `Scrippet setting "${key}" cannot construct an automatic css-var name from its key.`,
+      );
+    }
+    return true;
+  }
+  if (typeof raw !== "string") {
+    throw new Error(
+      `Scrippet setting "${key}" css-var must be true, false, or an explicit --scrippets-* custom property.`,
+    );
+  }
+
+  const value = raw.trim();
+  if (!CSS_CUSTOM_PROPERTY.test(value)) {
+    throw new Error(
+      `Scrippet setting "${key}" has invalid css-var "${value}". CSS custom properties must start with --scrippets-.`,
+    );
+  }
+  return value;
 }
 
 function parseOptions(key: string, raw: unknown): ScrippetParameterOption[] {
@@ -272,6 +343,14 @@ function humanize(value: string): string {
   return value
     .replace(/[-_]+/g, " ")
     .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function toCssNamePart(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from "obsidian";
 
 export type ScrippetParameterType = "boolean" | "number" | "string" | "select";
+export type ScrippetParameterControl = "auto" | "slider" | "number";
 export type ScrippetParameterValue = boolean | number | string;
 
 export interface ScrippetParameterOption {
@@ -17,8 +18,9 @@ export interface ScrippetParameterDefinition {
   max?: number;
   step?: number;
   unit?: string;
+  control?: ScrippetParameterControl;
   options?: ScrippetParameterOption[];
-  cssVar?: string;
+  cssVar?: true | string;
 }
 
 export type ScrippetParameterSchema = Record<string, ScrippetParameterDefinition>;

--- a/src/ui/parameter-settings-tab.ts
+++ b/src/ui/parameter-settings-tab.ts
@@ -15,6 +15,7 @@ import { ScrippetSettingTab } from "./settings-tab";
 
 export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
   private readonly scrippetPlugin: ScrippetPlugin;
+  private settingsSaveQueue: Promise<void> = Promise.resolve();
 
   constructor(app: App, plugin: ScrippetPlugin) {
     super(app, plugin);
@@ -67,7 +68,7 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
           .setTooltip("Reset all parameters to their defaults")
           .onClick(async () => {
             delete this.scrippetPlugin.settings.scrippetSettings[descriptor.id];
-            await this.scrippetPlugin.saveSettings();
+            await this.queueSettingsSave();
             this.syncParameterCss();
             this.redisplayPreservingScroll();
           }),
@@ -243,7 +244,7 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
 
     try {
       this.syncParameterCss();
-      await this.scrippetPlugin.saveSettings();
+      await this.queueSettingsSave();
     } catch (error) {
       console.error("Scrippets: failed to save parameter value", error);
       new Notice("Failed to save scrippet parameter.");
@@ -263,9 +264,15 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
       this.scrippetPlugin.settings.scrippetSettings[descriptor.id] = next;
     }
 
-    await this.scrippetPlugin.saveSettings();
+    await this.queueSettingsSave();
     this.syncParameterCss();
     this.redisplayPreservingScroll();
+  }
+
+  private queueSettingsSave(): Promise<void> {
+    const next = this.settingsSaveQueue.then(() => this.scrippetPlugin.saveSettings());
+    this.settingsSaveQueue = next.catch(() => undefined);
+    return next;
   }
 
   private getParameterizedDescriptors(): ScrippetDescriptor[] {

--- a/src/ui/parameter-settings-tab.ts
+++ b/src/ui/parameter-settings-tab.ts
@@ -2,7 +2,9 @@ import { App, Notice, Setting } from "obsidian";
 import type ScrippetPlugin from "../main";
 import {
   coerceScrippetParameterValue,
+  resolveScrippetParameterCssVarName,
   resolveScrippetParameterValues,
+  shouldUseScrippetParameterSlider,
 } from "../parameters";
 import type {
   ScrippetDescriptor,
@@ -34,7 +36,9 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
 
     new Setting(this.containerEl)
       .setName("Scrippet parameters")
-      .setDesc("Values are stored by scrippet ID and passed to invoke(plugin, settings).")
+      .setDesc(
+        "Tune values declared by each scrippet. Changes are saved by scrippet ID and passed to invoke(plugin, settings).",
+      )
       .setHeading();
 
     const section = this.containerEl.createDiv({ cls: "scrippet-parameter-section" });
@@ -58,12 +62,15 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
 
     if (this.hasSavedValues(descriptor.id)) {
       header.addButton((button) =>
-        button.setButtonText("Reset").setTooltip("Reset parameters to defaults").onClick(async () => {
-          delete this.scrippetPlugin.settings.scrippetSettings[descriptor.id];
-          await this.scrippetPlugin.saveSettings();
-          this.syncParameterCss();
-          this.redisplayPreservingScroll();
-        }),
+        button
+          .setButtonText("Reset all")
+          .setTooltip("Reset all parameters to their defaults")
+          .onClick(async () => {
+            delete this.scrippetPlugin.settings.scrippetSettings[descriptor.id];
+            await this.scrippetPlugin.saveSettings();
+            this.syncParameterCss();
+            this.redisplayPreservingScroll();
+          }),
       );
     }
 
@@ -86,6 +93,7 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
   ): void {
     const setting = new Setting(container).setName(definition.label);
     if (definition.description) setting.setDesc(definition.description);
+    this.renderParameterDetails(setting, descriptor, key, definition);
 
     if (definition.type === "boolean") {
       setting.addToggle((toggle) =>
@@ -93,10 +101,7 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
           await this.saveParameterValue(descriptor, key, definition, next);
         }),
       );
-      return;
-    }
-
-    if (definition.type === "select") {
+    } else if (definition.type === "select") {
       setting.addDropdown((dropdown) => {
         for (const option of definition.options ?? []) {
           dropdown.addOption(option.value, option.label);
@@ -105,32 +110,122 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
           await this.saveParameterValue(descriptor, key, definition, next);
         });
       });
-      return;
+    } else if (definition.type === "number") {
+      this.renderNumberControl(setting, descriptor, key, definition, Number(value));
+    } else {
+      this.renderTextControl(setting, descriptor, key, definition, String(value));
+    }
+
+    setting.addExtraButton((button) =>
+      button
+        .setIcon("rotate-ccw")
+        .setTooltip(`Reset to default (${this.formatParameterValue(definition, definition.default)})`)
+        .onClick(async () => {
+          await this.resetParameterValue(descriptor, key);
+        }),
+    );
+  }
+
+  private renderNumberControl(
+    setting: Setting,
+    descriptor: ScrippetDescriptor,
+    key: string,
+    definition: ScrippetParameterDefinition,
+    value: number,
+  ): void {
+    let setSliderValue: ((next: number) => void) | undefined;
+    let numberInput: HTMLInputElement | undefined;
+
+    if (shouldUseScrippetParameterSlider(definition)) {
+      const min = definition.min ?? 0;
+      const max = definition.max ?? 100;
+      const step = definition.step ?? 1;
+      setting.addSlider((slider) => {
+        slider.setLimits(min, max, step).setValue(value);
+        setSliderValue = (next) => slider.setValue(next);
+        slider.onChange(async (next) => {
+          if (numberInput) numberInput.value = String(next);
+          await this.saveParameterValue(descriptor, key, definition, next);
+        });
+      });
     }
 
     setting.addText((text) => {
+      numberInput = text.inputEl;
+      text.inputEl.addClass("scrippet-parameter-number-input");
       text.setValue(String(value));
-      if (definition.type === "number") {
-        text.inputEl.type = "number";
-        if (definition.min != null) text.inputEl.min = String(definition.min);
-        if (definition.max != null) text.inputEl.max = String(definition.max);
-        if (definition.step != null) text.inputEl.step = String(definition.step);
-      }
+      text.inputEl.type = "number";
+      if (definition.min != null) text.inputEl.min = String(definition.min);
+      if (definition.max != null) text.inputEl.max = String(definition.max);
+      if (definition.step != null) text.inputEl.step = String(definition.step);
       text.onChange(async (next) => {
-        if (definition.type === "number" && next.trim() === "") return;
+        if (next.trim() === "") return;
         try {
-          await this.saveParameterValue(descriptor, key, definition, next);
-          text.inputEl.classList.remove("scrippet-parameter-invalid");
+          const coerced = coerceScrippetParameterValue(definition, next);
+          const numeric = Number(coerced);
+          setSliderValue?.(numeric);
+          text.setValue(String(numeric));
+          await this.saveParameterValue(descriptor, key, definition, numeric);
+          text.inputEl.removeClass("scrippet-parameter-invalid");
         } catch (error) {
-          text.inputEl.classList.add("scrippet-parameter-invalid");
+          text.inputEl.addClass("scrippet-parameter-invalid");
           console.debug(`Scrippets: invalid parameter ${descriptor.id}.${key}`, error);
         }
       });
     });
 
-    if (definition.type === "number" && definition.unit) {
+    if (definition.unit) {
       setting.controlEl.createSpan({ cls: "scrippet-parameter-unit", text: definition.unit });
     }
+  }
+
+  private renderTextControl(
+    setting: Setting,
+    descriptor: ScrippetDescriptor,
+    key: string,
+    definition: ScrippetParameterDefinition,
+    value: string,
+  ): void {
+    setting.addText((text) => {
+      text.setValue(value).onChange(async (next) => {
+        try {
+          await this.saveParameterValue(descriptor, key, definition, next);
+          text.inputEl.removeClass("scrippet-parameter-invalid");
+        } catch (error) {
+          text.inputEl.addClass("scrippet-parameter-invalid");
+          console.debug(`Scrippets: invalid parameter ${descriptor.id}.${key}`, error);
+        }
+      });
+    });
+  }
+
+  private renderParameterDetails(
+    setting: Setting,
+    descriptor: ScrippetDescriptor,
+    key: string,
+    definition: ScrippetParameterDefinition,
+  ): void {
+    const details = setting.descEl.createDiv({ cls: "scrippet-parameter-details" });
+    details.createSpan({
+      cls: "scrippet-parameter-default",
+      text: `Default: ${this.formatParameterValue(definition, definition.default)}`,
+    });
+
+    const cssVar = resolveScrippetParameterCssVarName(descriptor.id, key, definition);
+    if (cssVar) {
+      const cssDetail = details.createSpan({ cls: "scrippet-parameter-css-var" });
+      cssDetail.createSpan({ text: "CSS: " });
+      cssDetail.createEl("code", { text: cssVar });
+    }
+  }
+
+  private formatParameterValue(
+    definition: ScrippetParameterDefinition,
+    value: ScrippetParameterValue,
+  ): string {
+    if (definition.type === "number") return `${value}${definition.unit ?? ""}`;
+    if (definition.type === "boolean") return value ? "On" : "Off";
+    return String(value);
   }
 
   private async saveParameterValue(
@@ -147,13 +242,30 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
     };
 
     try {
-      await this.scrippetPlugin.saveSettings();
       this.syncParameterCss();
+      await this.scrippetPlugin.saveSettings();
     } catch (error) {
       console.error("Scrippets: failed to save parameter value", error);
       new Notice("Failed to save scrippet parameter.");
       throw error;
     }
+  }
+
+  private async resetParameterValue(descriptor: ScrippetDescriptor, key: string): Promise<void> {
+    const current = this.scrippetPlugin.settings.scrippetSettings[descriptor.id];
+    if (!current || !Object.prototype.hasOwnProperty.call(current, key)) return;
+
+    const next = { ...current };
+    delete next[key];
+    if (Object.keys(next).length === 0) {
+      delete this.scrippetPlugin.settings.scrippetSettings[descriptor.id];
+    } else {
+      this.scrippetPlugin.settings.scrippetSettings[descriptor.id] = next;
+    }
+
+    await this.scrippetPlugin.saveSettings();
+    this.syncParameterCss();
+    this.redisplayPreservingScroll();
   }
 
   private getParameterizedDescriptors(): ScrippetDescriptor[] {

--- a/src/ui/parameter-settings-tab.ts
+++ b/src/ui/parameter-settings-tab.ts
@@ -141,7 +141,7 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
       const max = definition.max ?? 100;
       const step = definition.step ?? 1;
       setting.addSlider((slider) => {
-        slider.setLimits(min, max, step).setValue(value);
+        slider.setLimits(min, max, step).setValue(value).setInstant(true);
         setSliderValue = (next) => slider.setValue(next);
         slider.onChange(async (next) => {
           if (numberInput) numberInput.value = String(next);

--- a/styles.css
+++ b/styles.css
@@ -214,6 +214,28 @@
   padding-right: 0;
 }
 
+.scrippet-parameter-details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  margin-top: 3px;
+  font-size: var(--font-smallest);
+  color: var(--text-faint);
+}
+
+.scrippet-parameter-css-var code {
+  user-select: all;
+}
+
+.scrippet-parameter-number-input {
+  width: 5.5em;
+}
+
+.scrippet-parameter-card input[type="range"] {
+  min-width: 120px;
+  flex: 1 1 160px;
+}
+
 .scrippet-parameter-unit {
   min-width: 2em;
   color: var(--text-muted);

--- a/tests/parameters.test.ts
+++ b/tests/parameters.test.ts
@@ -4,7 +4,9 @@ import {
   coerceScrippetParameterValue,
   formatScrippetParameterCssValue,
   parseScrippetParameterSchema,
+  resolveScrippetParameterCssVarName,
   resolveScrippetParameterValues,
+  shouldUseScrippetParameterSlider,
 } from "../src/parameters.ts";
 
 test("parses supported parameter types and defaults", () => {
@@ -17,7 +19,8 @@ test("parses supported parameter types and defaults", () => {
       min: 0,
       max: 200,
       unit: "px",
-      "css-var": "--scrippets-margin",
+      control: "slider",
+      "css-var": true,
     },
     title: { type: "string", default: "Example" },
     mode: {
@@ -30,7 +33,8 @@ test("parses supported parameter types and defaults", () => {
   assert.ok(schema);
   assert.equal(schema.enabled.default, true);
   assert.equal(schema.margin.default, 48);
-  assert.equal(schema.margin.cssVar, "--scrippets-margin");
+  assert.equal(schema.margin.control, "slider");
+  assert.equal(schema.margin.cssVar, true);
   assert.equal(schema.title.label, "Title");
   assert.deepEqual(schema.mode.options, [
     { value: "compact", label: "Compact" },
@@ -70,6 +74,47 @@ test("coerces UI values and formats CSS values", () => {
   assert.equal(formatScrippetParameterCssValue(schema.enabled, false), "0");
 });
 
+test("constructs CSS variable names from scrippet id and parameter key", () => {
+  const schema = parseScrippetParameterSchema({
+    "fade-width": { type: "number", default: 32, "css-var": true },
+    explicit: {
+      type: "number",
+      default: 1,
+      "css-var": "--scrippets-custom-override",
+    },
+    internal: { type: "number", default: 48 },
+  });
+  assert.ok(schema);
+
+  assert.equal(
+    resolveScrippetParameterCssVarName("toggle-wrap", "fade-width", schema["fade-width"]),
+    "--scrippets-toggle-wrap-fade-width",
+  );
+  assert.equal(
+    resolveScrippetParameterCssVarName("toggle-wrap", "explicit", schema.explicit),
+    "--scrippets-custom-override",
+  );
+  assert.equal(
+    resolveScrippetParameterCssVarName("toggle-wrap", "internal", schema.internal),
+    undefined,
+  );
+});
+
+test("uses sliders for bounded numbers unless the schema opts out", () => {
+  const schema = parseScrippetParameterSchema({
+    automatic: { type: "number", default: 50, min: 0, max: 100 },
+    slider: { type: "number", default: 50, min: 0, max: 100, control: "slider" },
+    number: { type: "number", default: 50, min: 0, max: 100, control: "number" },
+    unbounded: { type: "number", default: 50 },
+  });
+  assert.ok(schema);
+
+  assert.equal(shouldUseScrippetParameterSlider(schema.automatic), true);
+  assert.equal(shouldUseScrippetParameterSlider(schema.slider), true);
+  assert.equal(shouldUseScrippetParameterSlider(schema.number), false);
+  assert.equal(shouldUseScrippetParameterSlider(schema.unbounded), false);
+});
+
 test("rejects invalid schemas", () => {
   assert.throws(
     () => parseScrippetParameterSchema({ bad: { type: "number", min: 10, max: 5 } }),
@@ -85,5 +130,16 @@ test("rejects invalid schemas", () => {
         bad: { type: "number", "css-var": "--text-normal" },
       }),
     /must start with --scrippets-/,
+  );
+  assert.throws(
+    () =>
+      parseScrippetParameterSchema({
+        bad: { type: "number", control: "slider", min: 0 },
+      }),
+    /must declare min and max/,
+  );
+  assert.throws(
+    () => parseScrippetParameterSchema({ bad: { type: "string", control: "slider" } }),
+    /can only use control when type is number/,
   );
 });


### PR DESCRIPTION
## Summary
- render bounded numeric parameters as a slider plus precise numeric input by default
- add `control: auto|slider|number` for number-parameter UI selection
- apply slider changes continuously and serialize settings writes so rapid dragging cannot persist out of order
- show each parameter's default value, CSS variable name, and per-parameter reset action in the settings panel
- support `css-var: true` to generate `--scrippets-<scrippet-id>-<parameter-key>` automatically while preserving explicit `--scrippets-*` overrides
- update the Toggle Wrap / nowrap examples to use sliders and generated CSS variable names
- update README, styles, changelog, and parameter regression coverage

## Validation
- `node --check` passes for the updated `examples/toggle_nowrap.js`
- focused TypeScript validation of the parameter parser, CSS registry, and parameter settings UI passed against minimal Obsidian API stubs
- focused runtime checks for automatic CSS variable naming, slider selection, and invalid slider schemas passed
- full `npm run check` and `npm run build` could not be run in this environment because repository/package network access is unavailable

## Manual verification recommended
- open Settings → Scrippets and confirm bounded numbers show a slider and numeric input
- drag a CSS-bound slider and confirm the dependent snippet updates continuously
- type an exact numeric value and confirm the slider tracks it
- reset one parameter and then reset all parameters
- verify `css-var: true` displays and applies the generated `--scrippets-<id>-<key>` name