### PR TITLE
Declare configurable parameters in CSS snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ All notable changes to this project will be documented in this file. Dates use t
 - Add optional `css-var` bindings so parameter values can configure dependent CSS snippets through custom properties.
 - Add slider controls for bounded numeric parameters with precise numeric inputs and `control: auto|slider|number` schema selection.
 - Add automatic CSS custom-property names with `css-var: true`, using `--scrippets-<scrippet-id>-<parameter-key>` by default.
+- Add `@scrippets-setting` annotations in CSS snippets so custom-property defaults, units, bounds, and controls can be declared beside the styles that use them.
+- Watch the CSS snippets folder for parameter metadata changes and optionally expose CSS-owned values to `invoke(plugin, settings)` with a `key` annotation.
 
 ### Changed
 - Extend the nowrap example with configurable cursor margin, fade width, and scrollbar clearance plus a matching CSS snippet example.
 - Prefer block-comment `@settings` metadata in JavaScript examples so scrippet files remain valid JavaScript for external tooling.
 - Show parameter defaults, resolved CSS custom-property names, and per-parameter reset actions in the settings panel.
+- Move the nowrap fade and scrollbar settings into `nowrap.css`; resetting CSS-owned parameters now removes the inline override so the CSS declaration remains the source of the default.
 
 ### Fixed
 - Mask YAML frontmatter before JavaScript evaluation so frontmatter-based scrippets remain executable while preserving source line layout.
@@ -75,7 +78,7 @@ All notable changes to this project will be documented in this file. Dates use t
 
 ## [1.1.1] - 2025-09-23
 ### Added
-- Add metadata-first scanning with header previews, first-run context, and accessible modals.
+- Document metadata-first scanning with header previews and accessible first-run modals introduced after 1.1.1.
 - Add settings controls to open scrippet files and copy their vault-relative paths.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Obsidian Scrippets lets you author small JavaScript “scrippets” right inside
 - Per-scrippet enable/disable switches, first-run confirmation, manual run buttons, and persisted parameter values.
 - Typed parameter controls for booleans, numbers, strings, and select menus in the Scrippets settings panel.
 - Bounded numeric parameters use a slider plus precise number input by default, with schema overrides for slider-only intent or number-input intent.
-- Optional CSS custom-property bindings with automatic `--scrippets-<id>-<parameter>` names so parameters can configure dependent CSS snippets without rewriting snippet files.
+- Required CSS snippets can declare their own configurable custom properties directly in the `.css` file, keeping CSS defaults, units, and controls beside the styles that consume them.
+- JavaScript parameters can still bind to CSS custom properties with automatic `--scrippets-<id>-<parameter>` names when that ownership model is useful.
 - Startup folder support with explicit opt-in, per-file toggles, and one-time approval for untrusted startup scrippets.
 - Per-scrippet overlap protection while an invocation is still running.
 - A bounded, session-local recent execution log with duration and failure details.
@@ -61,7 +62,7 @@ An optional block comment at the top of the file can provide directives:
 - `@id` – stable identifier; otherwise derived from the filename
 - `@desc` – short description shown in settings
 - `@requires-snippet` – CSS snippet id that must exist in `<vault config dir>/snippets/` before the scrippet can run; use the snippet filename with or without the `.css` extension
-- `@settings` – JSON or YAML mapping describing configurable parameters
+- `@settings` – JSON or YAML mapping describing configurable JavaScript parameters
 
 A required snippet only needs to exist. Its enabled/disabled state remains under the scrippet's control, which allows commands such as Toggle Wrap to enable and disable their own snippet. Missing dependencies fail through the normal execution error path and are included in recent execution history.
 
@@ -69,7 +70,7 @@ The same metadata can also be supplied through YAML frontmatter. Scrippets masks
 
 ### Configurable parameters
 
-Structured parameters can be declared with `@settings` inside the metadata comment. Keeping the schema inside a comment means the file remains valid JavaScript. Parameter values are stored by scrippet ID and passed as the second argument to `invoke`.
+Structured JavaScript parameters can be declared with `@settings` inside the metadata comment. Keeping the schema inside a comment means the file remains valid JavaScript. Parameter values are stored by scrippet ID and passed as the second argument to `invoke`.
 
 ```js
 /*
@@ -89,9 +90,7 @@ Structured parameters can be declared with `@settings` inside the metadata comme
     "min": 0,
     "max": 100,
     "step": 1,
-    "unit": "px",
-    "control": "slider",
-    "css-var": true
+    "unit": "px"
   },
   "message": {
     "type": "string",
@@ -120,45 +119,59 @@ Supported parameter types are `boolean`, `number`, `string`, and `select`. Numbe
 
 Structured `settings` metadata is also accepted through YAML frontmatter for compatibility, but comment metadata is recommended when the scrippet should remain standalone-valid JavaScript.
 
-The settings panel shows a **Scrippet parameters** section for every loaded scrippet that declares parameters. Each parameter shows its default value, CSS custom-property name when applicable, and an individual reset action. A **Reset all** button removes every saved override for that scrippet.
+The settings panel shows a **Scrippet parameters** section for every loaded scrippet that declares parameters itself or requires a CSS snippet that declares parameters. Each parameter shows its default value, CSS custom-property name when applicable, source file for CSS-owned parameters, and an individual reset action. A **Reset all** button removes every saved override for that scrippet.
 
 ### Configuring CSS snippets with parameters
 
-A parameter can optionally bind to a CSS custom property with `css-var`. Set `"css-var": true` to have Scrippets construct the name automatically as `--scrippets-<scrippet-id>-<parameter-key>`. The stable scrippet ID and parameter key determine the generated name, so changing a display label does not change the CSS API.
+CSS-facing parameters can be declared where the custom property is defined. When a scrippet uses `@requires-snippet: nowrap`, Scrippets scans `<vault config dir>/snippets/nowrap.css` for `@scrippets-setting` comments immediately followed by a `--scrippets-*` custom-property declaration.
 
-For example, with `@id: toggle-wrap`:
+```css
+:root {
+  /*
+   * @scrippets-setting
+   * label: Edge fade width
+   * description: Width of the continuation fade at the right edge.
+   * min: 0px
+   * max: 100px
+   * step: 1px
+   * control: slider
+   */
+  --scrippets-nowrap-fade-width: 32px;
 
-```json
-{
-  "fade-width": {
-    "type": "number",
-    "label": "Edge fade width",
-    "default": 32,
-    "min": 0,
-    "max": 100,
-    "unit": "px",
-    "css-var": true
-  }
+  /*
+   * @scrippets-setting
+   * label: Scrollbar clearance
+   * min: 0px
+   * max: 40px
+   * step: 1px
+   */
+  --scrippets-nowrap-scrollbar-offset: 12px;
 }
 ```
 
-Scrippets exposes:
+The custom-property declaration is the source of the default value and unit. A value such as `32px` is inferred as a numeric parameter with default `32` and unit `px`; non-numeric declarations are exposed as string parameters. `min`, `max`, and `step` may include the same unit as the declaration or omit the unit. `control` accepts `auto`, `slider`, or `number`; bounded numeric values use a slider plus exact number input by default.
+
+`label` and `description` are optional. If `label` is omitted, Scrippets derives it from the variable name. For a snippet named `nowrap.css`, `--scrippets-nowrap-fade-width` becomes the setting key `fade-width` and label `Fade Width`.
+
+By default a CSS-owned parameter is only used to update the custom property. Add `key` when JavaScript should receive the same value through `invoke(plugin, settings)`:
 
 ```css
---scrippets-toggle-wrap-fade-width: 32px;
+/*
+ * @scrippets-setting
+ * key: fade-width
+ * min: 0px
+ * max: 100px
+ */
+--scrippets-nowrap-edge-width: 32px;
 ```
 
-The dependent CSS snippet can use a fallback normally:
+The scrippet can then read `settings["fade-width"]`. Without `key`, the setting remains CSS-only.
 
-```css
-.cm-editor::after {
-  width: var(--scrippets-toggle-wrap-fade-width, 32px);
-}
-```
+Saved CSS overrides are applied as inline custom properties so changes are visible immediately. Resetting a CSS-owned parameter removes the inline override instead of writing the default value; the declaration in the CSS snippet naturally becomes active again. This means changing `--scrippets-nowrap-fade-width: 32px` to `40px` changes the default in one place. Scrippets watches the snippets folder and refreshes the settings panel when annotated snippet files change.
 
-If a different stable property name is needed, `css-var` may instead be an explicit `--scrippets-*` string. Omitting `css-var` (or setting it to `false`) keeps the parameter JavaScript-only. For CSS-bound number parameters, `unit` is appended to the custom-property value. Boolean values are exposed as `1` or `0`; string and select values are passed through as text. When more than one loaded scrippet binds the same CSS variable, the scrippet with the later ID in lexical order wins.
+JavaScript-owned parameters may still use `"css-var": true` to construct `--scrippets-<scrippet-id>-<parameter-key>` automatically, or provide an explicit `--scrippets-*` string. This remains useful when the JavaScript behavior is the natural owner of a setting. For purely visual values, CSS-owned declarations are recommended.
 
-See `examples/toggle_nowrap.js` and `examples/nowrap.css` for a complete scrippet + snippet pair that exposes cursor margin, edge fade width, and scrollbar clearance through the settings panel.
+See `examples/toggle_nowrap.js` and `examples/nowrap.css` for a complete pair: cursor margin remains JavaScript-owned, while edge fade width and scrollbar clearance are declared in `nowrap.css`.
 
 ### Startup scripts
 
@@ -171,7 +184,7 @@ Open **Settings → Community plugins → Scrippets** to:
 - Change the scrippet folder.
 - Toggle startup execution, confirm-first-run, and review safety warnings.
 - Inspect loaded commands, enable/disable them, and run them manually.
-- Configure parameters declared by scrippets with sliders, precise inputs, generated CSS-variable details, and reset actions.
+- Configure JavaScript and CSS-snippet parameters with sliders, precise inputs, source/default details, and reset actions.
 - View load errors or skipped files (e.g., duplicate IDs).
 - Add new files via the **+** dialog, including templates for the supported export shapes.
 - See whether a scrippet is currently running.
@@ -210,7 +223,7 @@ See [CHANGELOG.md](./CHANGELOG.md) for a human-readable history of updates.
 1. Confirm the working tree is clean and the GitHub CLI (`gh`) is authenticated (`gh auth login`).
 2. Run `npm run release -- --type=patch` (default) or `--type=minor` / `--type=major` depending on the bump you need.
    - To specify an exact version instead, use `npm run release -- --version=1.2.3`.
-3. The release script will build the bundle, run `npm version`, push the branch and tags, and create the GitHub release using the notes from `CHANGELOG.md`.
+3. The release script will build the bundle, run `npm version`, push the branch and tags, and create a GitHub release using the notes from `CHANGELOG.md`.
    - Add `--no-push` to skip pushing, or `--no-publish` to skip the GitHub release step.
 
 ## Project structure
@@ -222,6 +235,7 @@ obsidian-scrippets/
 │   ├── scrippet-manager.ts
 │   ├── metadata.ts
 │   ├── parameters.ts
+│   ├── css-snippet-parameters.ts
 │   └── ui/             # Settings UI and modals
 ├── examples/
 ├── esbuild.config.mjs
@@ -230,7 +244,7 @@ obsidian-scrippets/
 ├── versions.json
 ├── styles.css
 ├── scripts/
-│   └── release.mjs    # release automation script
+│   └── release.mjs    # release automation
 └── package.json
 ```
 

--- a/examples/nowrap.css
+++ b/examples/nowrap.css
@@ -1,3 +1,27 @@
+:root {
+  /*
+   * @scrippets-setting
+   * label: Edge fade width
+   * description: Width of the continuation fade at the right edge.
+   * min: 0px
+   * max: 100px
+   * step: 1px
+   * control: slider
+   */
+  --scrippets-nowrap-fade-width: 32px;
+
+  /*
+   * @scrippets-setting
+   * label: Scrollbar clearance
+   * description: Keep the fade clear of the vertical scrollbar.
+   * min: 0px
+   * max: 40px
+   * step: 1px
+   * control: slider
+   */
+  --scrippets-nowrap-scrollbar-offset: 12px;
+}
+
 /* No wrap in editor (CM6) */
 .markdown-source-view.mod-cm6 .cm-content,
 .markdown-source-view.mod-cm6 .cm-line {
@@ -12,7 +36,7 @@
 
 /* Leave enough room to scroll the end of a long line clear of the fade. */
 .markdown-source-view.mod-cm6 .cm-content {
-  padding-right: var(--scrippets-toggle-wrap-fade-width, 32px) !important;
+  padding-right: var(--scrippets-nowrap-fade-width) !important;
 }
 
 .markdown-source-view.mod-cm6 .cm-editor {
@@ -24,9 +48,9 @@
   content: "";
   position: absolute;
   top: 0;
-  right: var(--scrippets-toggle-wrap-scrollbar-offset, 12px);
+  right: var(--scrippets-nowrap-scrollbar-offset);
   bottom: 0;
-  width: var(--scrippets-toggle-wrap-fade-width, 32px);
+  width: var(--scrippets-nowrap-fade-width);
   background: linear-gradient(to right, transparent, var(--background-primary));
   pointer-events: none;
   z-index: 10;

--- a/examples/toggle_nowrap.js
+++ b/examples/toggle_nowrap.js
@@ -14,30 +14,6 @@
     "step": 1,
     "unit": "px",
     "control": "slider"
-  },
-  "fade-width": {
-    "type": "number",
-    "label": "Edge fade width",
-    "description": "Width of the continuation fade at the right edge.",
-    "default": 32,
-    "min": 0,
-    "max": 100,
-    "step": 1,
-    "unit": "px",
-    "control": "slider",
-    "css-var": true
-  },
-  "scrollbar-offset": {
-    "type": "number",
-    "label": "Scrollbar clearance",
-    "description": "Keep the fade clear of the vertical scrollbar.",
-    "default": 12,
-    "min": 0,
-    "max": 40,
-    "step": 1,
-    "unit": "px",
-    "control": "slider",
-    "css-var": true
   }
 }
 */

--- a/src/css-snippet-parameters.ts
+++ b/src/css-snippet-parameters.ts
@@ -5,14 +5,13 @@ import {
 } from "./parameters";
 import { SerialTaskQueue } from "./serial-task-queue";
 import type {
-  CssSnippetParameterDefinition,
   CssSnippetParameterSchema,
   CssSnippetParameterSource,
   ScrippetParameterValues,
 } from "./types";
 
 const ANNOTATED_CUSTOM_PROPERTY =
-  /\/\*([\s\S]*?@scrippets-setting[\s\S]*?)\*\/\s*(--[A-Za-z0-9_-]+)\s*:\s*([^;{}]+);/g;
+  /\/\*((?:(?!\*\/)[\s\S])*?@scrippets-setting(?:(?!\*\/)[\s\S])*?)\*\/\s*(--[A-Za-z0-9_-]+)\s*:\s*([^;{}]+);/g;
 const CSS_CUSTOM_PROPERTY = /^--scrippets-[A-Za-z0-9_-]+$/;
 const CSS_NUMBER = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+))([A-Za-z%][A-Za-z0-9%_-]*)?$/;
 const ANNOTATION_FIELDS = new Set([
@@ -341,9 +340,6 @@ function parseBound(raw: string, expectedUnit: string, path: string): number {
     throw new Error(
       `CSS snippet setting "${path}" uses unit "${parsed.unit}" but the custom property uses "${expectedUnit || "no unit"}".`,
     );
-  }
-  if (!expectedUnit && parsed.unit) {
-    throw new Error(`CSS snippet setting "${path}" cannot add a unit to a unitless default.`);
   }
   return parsed.value;
 }

--- a/src/css-snippet-parameters.ts
+++ b/src/css-snippet-parameters.ts
@@ -1,0 +1,390 @@
+import { TFile, normalizePath, type Plugin, type TAbstractFile } from "obsidian";
+import {
+  coerceScrippetParameterValue,
+  parseScrippetParameterSchema,
+} from "./parameters";
+import { SerialTaskQueue } from "./serial-task-queue";
+import type {
+  CssSnippetParameterDefinition,
+  CssSnippetParameterSchema,
+  CssSnippetParameterSource,
+  ScrippetParameterValues,
+} from "./types";
+
+const ANNOTATED_CUSTOM_PROPERTY =
+  /\/\*([\s\S]*?@scrippets-setting[\s\S]*?)\*\/\s*(--[A-Za-z0-9_-]+)\s*:\s*([^;{}]+);/g;
+const CSS_CUSTOM_PROPERTY = /^--scrippets-[A-Za-z0-9_-]+$/;
+const CSS_NUMBER = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+))([A-Za-z%][A-Za-z0-9%_-]*)?$/;
+const ANNOTATION_FIELDS = new Set([
+  "label",
+  "description",
+  "desc",
+  "min",
+  "max",
+  "step",
+  "control",
+  "key",
+]);
+
+interface CssDimension {
+  value: number;
+  unit: string;
+}
+
+export class CssSnippetParameterCatalog {
+  private readonly queue = new SerialTaskQueue();
+  private readonly sources = new Map<string, CssSnippetParameterSource>();
+  private readonly listeners = new Set<() => void>();
+  private plugin?: Plugin;
+  private initialized = false;
+  private disposed = false;
+
+  get(id: string): CssSnippetParameterSource | undefined {
+    return this.sources.get(normalizeSnippetId(id));
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  async initialize(plugin: Plugin): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+    this.plugin = plugin;
+    await this.queue.run(() => this.scanAll());
+    this.registerWatchers(plugin);
+  }
+
+  destroy(): void {
+    this.disposed = true;
+    this.listeners.clear();
+    this.sources.clear();
+  }
+
+  private get snippetsFolder(): string {
+    const plugin = this.plugin;
+    if (!plugin) return "";
+    return normalizePath(`${plugin.app.vault.configDir}/snippets`);
+  }
+
+  private async scanAll(): Promise<void> {
+    const plugin = this.plugin;
+    if (!plugin || this.disposed) return;
+
+    const next = new Map<string, CssSnippetParameterSource>();
+    try {
+      const listing = await plugin.app.vault.adapter.list(this.snippetsFolder);
+      for (const path of listing.files
+        .map((file) => normalizePath(file))
+        .filter((file) => file.toLowerCase().endsWith(".css"))
+        .sort((a, b) => a.localeCompare(b))) {
+        const source = await this.readSource(path);
+        next.set(source.id, source);
+      }
+    } catch (error) {
+      console.debug(`Scrippets: unable to list ${this.snippetsFolder}`, error);
+    }
+
+    this.sources.clear();
+    for (const [id, source] of next) this.sources.set(id, source);
+    this.notify();
+  }
+
+  private async refreshPath(path: string): Promise<void> {
+    if (this.disposed || !this.isSnippetPath(path)) return;
+    const plugin = this.plugin;
+    if (!plugin) return;
+
+    const normalized = normalizePath(path);
+    const id = snippetIdFromPath(normalized);
+    const exists = await plugin.app.vault.adapter.exists(normalized);
+    if (!exists) {
+      this.sources.delete(id);
+      this.notify();
+      return;
+    }
+
+    this.sources.set(id, await this.readSource(normalized));
+    this.notify();
+  }
+
+  private async readSource(path: string): Promise<CssSnippetParameterSource> {
+    const plugin = this.plugin;
+    if (!plugin) throw new Error("CSS snippet catalog is not initialized.");
+
+    const normalized = normalizePath(path);
+    const id = snippetIdFromPath(normalized);
+    try {
+      const source = await plugin.app.vault.adapter.read(normalized);
+      const settings = parseCssSnippetParameterSchema(source, id);
+      return {
+        id,
+        path: normalized,
+        ...(settings ? { settings } : {}),
+      };
+    } catch (error) {
+      return {
+        id,
+        path: normalized,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private registerWatchers(plugin: Plugin): void {
+    const vault = plugin.app.vault;
+    plugin.registerEvent(vault.on("create", (file) => this.handleFileChange(file)));
+    plugin.registerEvent(vault.on("modify", (file) => this.handleFileChange(file)));
+    plugin.registerEvent(vault.on("delete", (file) => this.handleFileChange(file)));
+    plugin.registerEvent(
+      vault.on("rename", (file, oldPath) => {
+        if (!this.isSnippetPath(oldPath) && !this.isSnippetPath(file.path)) return;
+        void this.queue.run(async () => {
+          if (!(file instanceof TFile)) {
+            await this.scanAll();
+            return;
+          }
+          const oldId = snippetIdFromPath(oldPath);
+          if (this.isSnippetPath(oldPath)) this.sources.delete(oldId);
+          if (this.isSnippetPath(file.path)) await this.refreshPath(file.path);
+          else this.notify();
+        });
+      }),
+    );
+  }
+
+  private handleFileChange(file: TAbstractFile): void {
+    if (!(file instanceof TFile) || !this.isSnippetPath(file.path)) return;
+    void this.queue.run(() => this.refreshPath(file.path));
+  }
+
+  private isSnippetPath(path: string): boolean {
+    if (!this.snippetsFolder) return false;
+    const normalized = normalizePath(path);
+    return normalized.toLowerCase().endsWith(".css") && isWithin(normalized, this.snippetsFolder);
+  }
+
+  private notify(): void {
+    this.listeners.forEach((listener) => listener());
+  }
+}
+
+export function parseCssSnippetParameterSchema(
+  source: string,
+  snippetId: string,
+): CssSnippetParameterSchema | undefined {
+  const schema: CssSnippetParameterSchema = {};
+  const runtimeKeys = new Set<string>();
+  ANNOTATED_CUSTOM_PROPERTY.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = ANNOTATED_CUSTOM_PROPERTY.exec(source)) !== null) {
+    const body = match[1] ?? "";
+    const cssVar = match[2] ?? "";
+    const defaultText = (match[3] ?? "").trim();
+    if (!CSS_CUSTOM_PROPERTY.test(cssVar)) {
+      throw new Error(
+        `CSS snippet setting variable "${cssVar}" must start with --scrippets-.`,
+      );
+    }
+    if (!defaultText) {
+      throw new Error(`CSS snippet setting "${cssVar}" must declare a default value.`);
+    }
+
+    const metadata = parseAnnotation(body, cssVar);
+    const runtimeKey = metadata.key?.trim() || undefined;
+    const storageKey = runtimeKey ?? inferStorageKey(snippetId, cssVar);
+    if (!storageKey) {
+      throw new Error(`Unable to derive a setting key for CSS variable "${cssVar}".`);
+    }
+    if (schema[storageKey]) {
+      throw new Error(`CSS snippet declares duplicate setting key "${storageKey}".`);
+    }
+    if (runtimeKey) {
+      if (runtimeKeys.has(runtimeKey)) {
+        throw new Error(`CSS snippet declares duplicate runtime key "${runtimeKey}".`);
+      }
+      runtimeKeys.add(runtimeKey);
+    }
+
+    const rawDefinition = buildRawDefinition(storageKey, cssVar, defaultText, metadata);
+    const parsed = parseScrippetParameterSchema({ [storageKey]: rawDefinition });
+    const definition = parsed?.[storageKey];
+    if (!definition || definition.cssVar === true || typeof definition.cssVar !== "string") {
+      throw new Error(`Unable to parse CSS snippet setting "${cssVar}".`);
+    }
+
+    schema[storageKey] = {
+      ...definition,
+      cssVar: definition.cssVar,
+      ...(runtimeKey ? { runtimeKey } : {}),
+    };
+  }
+
+  return Object.keys(schema).length > 0 ? schema : undefined;
+}
+
+export function resolveCssSnippetRuntimeValues(
+  schema: CssSnippetParameterSchema | undefined,
+  saved: ScrippetParameterValues | undefined,
+): ScrippetParameterValues {
+  const values: ScrippetParameterValues = {};
+  if (!schema) return values;
+
+  for (const [storageKey, definition] of Object.entries(schema)) {
+    const runtimeKey = definition.runtimeKey;
+    if (!runtimeKey) continue;
+    const raw = saved?.[storageKey];
+    if (raw === undefined) {
+      values[runtimeKey] = definition.default;
+      continue;
+    }
+    try {
+      values[runtimeKey] = coerceScrippetParameterValue(definition, raw);
+    } catch {
+      values[runtimeKey] = definition.default;
+    }
+  }
+  return values;
+}
+
+function buildRawDefinition(
+  storageKey: string,
+  cssVar: string,
+  defaultText: string,
+  metadata: Record<string, string>,
+): Record<string, unknown> {
+  const label = metadata.label?.trim() || humanize(storageKey);
+  const description = metadata.description?.trim() || metadata.desc?.trim() || undefined;
+  const numericDefault = parseCssDimension(defaultText);
+
+  if (!numericDefault) {
+    if (metadata.min || metadata.max || metadata.step || metadata.control) {
+      throw new Error(
+        `CSS snippet setting "${cssVar}" can only use min, max, step, or control when its default is numeric.`,
+      );
+    }
+    return {
+      type: "string",
+      label,
+      ...(description ? { description } : {}),
+      default: defaultText,
+      "css-var": cssVar,
+    };
+  }
+
+  return {
+    type: "number",
+    label,
+    ...(description ? { description } : {}),
+    default: numericDefault.value,
+    ...(numericDefault.unit ? { unit: numericDefault.unit } : {}),
+    ...(metadata.min
+      ? { min: parseBound(metadata.min, numericDefault.unit, `${cssVar}.min`) }
+      : {}),
+    ...(metadata.max
+      ? { max: parseBound(metadata.max, numericDefault.unit, `${cssVar}.max`) }
+      : {}),
+    ...(metadata.step
+      ? { step: parseBound(metadata.step, numericDefault.unit, `${cssVar}.step`) }
+      : {}),
+    ...(metadata.control ? { control: metadata.control.trim() } : {}),
+    "css-var": cssVar,
+  };
+}
+
+function parseAnnotation(body: string, cssVar: string): Record<string, string> {
+  const lines = body
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^\s*\*\s?/, "").trimEnd());
+  const markerIndex = lines.findIndex((line) => line.trim() === "@scrippets-setting");
+  if (markerIndex < 0) return {};
+
+  const metadata: Record<string, string> = {};
+  for (const line of lines.slice(markerIndex + 1)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const separator = trimmed.indexOf(":");
+    if (separator <= 0) {
+      throw new Error(
+        `CSS snippet setting "${cssVar}" metadata line "${trimmed}" must use key: value syntax.`,
+      );
+    }
+    const key = trimmed.slice(0, separator).trim().toLowerCase();
+    const value = trimmed.slice(separator + 1).trim();
+    if (!ANNOTATION_FIELDS.has(key)) {
+      throw new Error(`CSS snippet setting "${cssVar}" has unknown metadata field "${key}".`);
+    }
+    if (!value) {
+      throw new Error(`CSS snippet setting "${cssVar}" field "${key}" cannot be empty.`);
+    }
+    metadata[key] = value;
+  }
+  return metadata;
+}
+
+function parseCssDimension(raw: string): CssDimension | null {
+  const match = CSS_NUMBER.exec(raw.trim());
+  if (!match) return null;
+  const value = Number(match[1]);
+  if (!Number.isFinite(value)) return null;
+  return { value, unit: match[2] ?? "" };
+}
+
+function parseBound(raw: string, expectedUnit: string, path: string): number {
+  const parsed = parseCssDimension(raw);
+  if (!parsed) {
+    throw new Error(`CSS snippet setting "${path}" must be a numeric value.`);
+  }
+  if (parsed.unit && parsed.unit !== expectedUnit) {
+    throw new Error(
+      `CSS snippet setting "${path}" uses unit "${parsed.unit}" but the custom property uses "${expectedUnit || "no unit"}".`,
+    );
+  }
+  if (!expectedUnit && parsed.unit) {
+    throw new Error(`CSS snippet setting "${path}" cannot add a unit to a unitless default.`);
+  }
+  return parsed.value;
+}
+
+function inferStorageKey(snippetId: string, cssVar: string): string {
+  const idPart = toCssNamePart(snippetId);
+  const scopedPrefix = idPart ? `--scrippets-${idPart}-` : "";
+  const raw =
+    scopedPrefix && cssVar.startsWith(scopedPrefix)
+      ? cssVar.slice(scopedPrefix.length)
+      : cssVar.slice("--scrippets-".length);
+  return raw.trim();
+}
+
+function snippetIdFromPath(path: string): string {
+  const normalized = normalizePath(path);
+  const filename = normalized.split("/").pop() ?? normalized;
+  return normalizeSnippetId(filename);
+}
+
+function normalizeSnippetId(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.toLowerCase().endsWith(".css") ? trimmed.slice(0, -4) : trimmed;
+}
+
+function humanize(value: string): string {
+  return value
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function toCssNamePart(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function isWithin(path: string, folder: string): boolean {
+  const normalizedPath = normalizePath(path);
+  const normalizedFolder = normalizePath(folder).replace(/\/$/, "");
+  return normalizedPath === normalizedFolder || normalizedPath.startsWith(`${normalizedFolder}/`);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { Notice, Plugin, normalizePath } from "obsidian";
+import { CssSnippetParameterCatalog } from "./css-snippet-parameters";
 import { ScrippetParameterCssRegistry } from "./parameter-css";
 import { ScrippetManager } from "./scrippet-manager";
 import { DEFAULT_SETTINGS, type ScrippetPluginSettings } from "./types";
@@ -8,6 +9,7 @@ export default class ScrippetPlugin extends Plugin {
   settings: ScrippetPluginSettings = DEFAULT_SETTINGS;
   manager!: ScrippetManager;
   readonly parameterCss = new ScrippetParameterCssRegistry();
+  readonly snippetParameters = new CssSnippetParameterCatalog();
 
   async onload(): Promise<void> {
     await this.loadSettings();
@@ -21,6 +23,7 @@ export default class ScrippetPlugin extends Plugin {
 
   onunload(): void {
     this.parameterCss.clear();
+    this.snippetParameters.destroy();
     this.manager?.destroy();
   }
 
@@ -42,6 +45,7 @@ export default class ScrippetPlugin extends Plugin {
   private async initializeManager(): Promise<void> {
     try {
       await this.manager.initialize();
+      await this.snippetParameters.initialize(this);
       if (this.settings.runStartupOnLoad) {
         await this.manager.runStartupScripts();
       }

--- a/src/parameter-css.ts
+++ b/src/parameter-css.ts
@@ -1,14 +1,24 @@
 import {
+  coerceScrippetParameterValue,
   formatScrippetParameterCssValue,
   resolveScrippetParameterCssVarName,
   resolveScrippetParameterValues,
 } from "./parameters";
-import type { ScrippetDescriptor, ScrippetParameterValues } from "./types";
+import { getRequiredSnippetId } from "./snippet-dependency";
+import type {
+  CssSnippetParameterSource,
+  ScrippetDescriptor,
+  ScrippetParameterValues,
+} from "./types";
 
 interface PreviousCssValue {
   value: string;
   priority: string;
 }
+
+export type CssSnippetParameterLookup = (
+  id: string,
+) => CssSnippetParameterSource | undefined;
 
 export class ScrippetParameterCssRegistry {
   private readonly previous = new Map<string, PreviousCssValue>();
@@ -17,23 +27,46 @@ export class ScrippetParameterCssRegistry {
   sync(
     descriptors: readonly ScrippetDescriptor[],
     savedById: Record<string, ScrippetParameterValues>,
+    getSnippet?: CssSnippetParameterLookup,
   ): void {
     const root = document.documentElement;
     const next = new Map<string, string>();
     const sorted = [...descriptors].sort((a, b) => a.id.localeCompare(b.id));
 
     for (const descriptor of sorted) {
+      const saved = savedById[descriptor.id];
       const schema = descriptor.metadata.settings;
-      if (!schema) continue;
-      const values = resolveScrippetParameterValues(schema, savedById[descriptor.id]);
+      if (schema) {
+        const values = resolveScrippetParameterValues(schema, saved);
+        for (const [key, definition] of Object.entries(schema)) {
+          const name = resolveScrippetParameterCssVarName(descriptor.id, key, definition);
+          if (!name) continue;
+          next.set(
+            name,
+            formatScrippetParameterCssValue(definition, values[key] ?? definition.default),
+          );
+        }
+      }
 
-      for (const [key, definition] of Object.entries(schema)) {
-        const name = resolveScrippetParameterCssVarName(descriptor.id, key, definition);
-        if (!name) continue;
-        next.set(
-          name,
-          formatScrippetParameterCssValue(definition, values[key] ?? definition.default),
-        );
+      if (!getSnippet || !saved) continue;
+      let snippetId: string | undefined;
+      try {
+        snippetId = getRequiredSnippetId(descriptor.metadata);
+      } catch {
+        continue;
+      }
+      if (!snippetId) continue;
+      const snippetSchema = getSnippet(snippetId)?.settings;
+      if (!snippetSchema) continue;
+
+      for (const [key, definition] of Object.entries(snippetSchema)) {
+        if (!Object.prototype.hasOwnProperty.call(saved, key)) continue;
+        try {
+          const value = coerceScrippetParameterValue(definition, saved[key]);
+          next.set(definition.cssVar, formatScrippetParameterCssValue(definition, value));
+        } catch {
+          // Invalid saved values fall back to the declaration in the CSS snippet.
+        }
       }
     }
 

--- a/src/scrippet-loader.ts
+++ b/src/scrippet-loader.ts
@@ -1,4 +1,5 @@
 import { Notice, normalizePath, type Plugin } from "obsidian";
+import { resolveCssSnippetRuntimeValues } from "./css-snippet-parameters";
 import {
   maskScrippetFrontmatter,
   parseScrippetMetadata,
@@ -8,14 +9,19 @@ import { resolveScrippetParameterValues } from "./parameters";
 import { getRequiredSnippetId } from "./snippet-dependency";
 import { evaluateScrippetSource } from "./scrippet-runtime";
 import type {
+  CssSnippetParameterSource,
   ScrippetMetadata,
   ScrippetModule,
   ScrippetParameterSchema,
+  ScrippetParameterValues,
   ScrippetPluginSettings,
 } from "./types";
 
 interface ScrippetPluginHost extends Plugin {
   settings?: Partial<ScrippetPluginSettings>;
+  snippetParameters?: {
+    get: (id: string) => CssSnippetParameterSource | undefined;
+  };
 }
 
 export function loadScrippet(plugin: Plugin, source: string): ScrippetModule {
@@ -54,18 +60,37 @@ function withScrippetFeatures(
         }
       }
 
-      const settings = schema
-        ? resolveScrippetParameterValues(schema, getSavedSettings(plugin, scrippetId))
-        : undefined;
-      return instance.invoke(plugin, settings);
+      const saved = getSavedSettings(plugin, scrippetId);
+      const snippetValues = getSnippetRuntimeSettings(plugin, snippetId, saved);
+      const scrippetValues = schema ? resolveScrippetParameterValues(schema, saved) : {};
+      const settings = {
+        ...snippetValues,
+        ...scrippetValues,
+      };
+
+      return instance.invoke(plugin, Object.keys(settings).length > 0 ? settings : undefined);
     },
   };
 }
 
-function getSavedSettings(plugin: Plugin, scrippetId: string | undefined) {
+function getSavedSettings(
+  plugin: Plugin,
+  scrippetId: string | undefined,
+): ScrippetParameterValues | undefined {
   if (!scrippetId) return undefined;
   const host = plugin as ScrippetPluginHost;
   return host.settings?.scrippetSettings?.[scrippetId];
+}
+
+function getSnippetRuntimeSettings(
+  plugin: Plugin,
+  snippetId: string | undefined,
+  saved: ScrippetParameterValues | undefined,
+): ScrippetParameterValues {
+  if (!snippetId) return {};
+  const host = plugin as ScrippetPluginHost;
+  const source = host.snippetParameters?.get(snippetId);
+  return resolveCssSnippetRuntimeValues(source?.settings, saved);
 }
 
 function resolveScrippetId(source: string, metadata: ScrippetMetadata): string | undefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,20 @@ export interface ScrippetParameterDefinition {
 export type ScrippetParameterSchema = Record<string, ScrippetParameterDefinition>;
 export type ScrippetParameterValues = Record<string, ScrippetParameterValue>;
 
+export interface CssSnippetParameterDefinition extends ScrippetParameterDefinition {
+  cssVar: string;
+  runtimeKey?: string;
+}
+
+export type CssSnippetParameterSchema = Record<string, CssSnippetParameterDefinition>;
+
+export interface CssSnippetParameterSource {
+  id: string;
+  path: string;
+  settings?: CssSnippetParameterSchema;
+  error?: string;
+}
+
 export interface ScrippetMetadata {
   [key: string]: string | ScrippetParameterSchema | undefined;
   id?: string;

--- a/src/ui/parameter-settings-tab.ts
+++ b/src/ui/parameter-settings-tab.ts
@@ -6,12 +6,19 @@ import {
   resolveScrippetParameterValues,
   shouldUseScrippetParameterSlider,
 } from "../parameters";
+import { getRequiredSnippetId } from "../snippet-dependency";
 import type {
+  CssSnippetParameterSource,
   ScrippetDescriptor,
   ScrippetParameterDefinition,
   ScrippetParameterValue,
 } from "../types";
 import { ScrippetSettingTab } from "./settings-tab";
+
+interface ParameterDisplayOptions {
+  cssVarName?: string;
+  sourceLabel?: string;
+}
 
 export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
   private readonly scrippetPlugin: ScrippetPlugin;
@@ -22,6 +29,10 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
     this.scrippetPlugin = plugin;
     this.scrippetPlugin.manager.subscribe(() => {
       this.syncParameterCss();
+    });
+    this.scrippetPlugin.snippetParameters.subscribe(() => {
+      this.syncParameterCss();
+      if (this.containerEl.isConnected) this.redisplayPreservingScroll();
     });
   }
 
@@ -38,7 +49,7 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
     new Setting(this.containerEl)
       .setName("Scrippet parameters")
       .setDesc(
-        "Tune values declared by each scrippet. Changes are saved by scrippet ID and passed to invoke(plugin, settings).",
+        "Tune values declared by each scrippet and its required CSS snippet. Changes are saved by scrippet ID.",
       )
       .setHeading();
 
@@ -50,14 +61,16 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
 
   private renderScrippetParameters(container: HTMLElement, descriptor: ScrippetDescriptor): void {
     const schema = descriptor.metadata.settings;
-    if (!schema) return;
+    const snippet = this.getCssSnippetSource(descriptor);
+    const snippetSchema = snippet?.settings;
+    if (!schema && !snippetSchema && !snippet?.error) return;
 
     const card = container.createDiv({ cls: "scrippet-parameter-card" });
     const header = new Setting(card).setName(descriptor.name);
-    const requiredSnippet = descriptor.metadata["requires-snippet"];
+    const requiredSnippet = this.getRequiredSnippetId(descriptor);
     header.setDesc(
       requiredSnippet
-        ? `ID: ${descriptor.id} · CSS snippet: ${requiredSnippet}`
+        ? `ID: ${descriptor.id} · CSS snippet: ${requiredSnippet}.css`
         : `ID: ${descriptor.id}`,
     );
 
@@ -75,13 +88,41 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
       );
     }
 
-    const values = resolveScrippetParameterValues(
-      schema,
-      this.scrippetPlugin.settings.scrippetSettings[descriptor.id],
-    );
+    if (snippet?.error) {
+      card.createDiv({
+        cls: "scrippet-error",
+        text: `Could not read CSS snippet parameters from ${snippet.path}: ${snippet.error}`,
+      });
+    }
 
-    for (const [key, definition] of Object.entries(schema)) {
-      this.renderParameterControl(card, descriptor, key, definition, values[key] ?? definition.default);
+    const saved = this.scrippetPlugin.settings.scrippetSettings[descriptor.id];
+    const values = resolveScrippetParameterValues(schema, saved);
+    for (const [key, definition] of Object.entries(schema ?? {})) {
+      this.renderParameterControl(
+        card,
+        descriptor,
+        key,
+        definition,
+        values[key] ?? definition.default,
+        {
+          cssVarName: resolveScrippetParameterCssVarName(descriptor.id, key, definition),
+        },
+      );
+    }
+
+    const snippetValues = resolveScrippetParameterValues(snippetSchema, saved);
+    for (const [key, definition] of Object.entries(snippetSchema ?? {})) {
+      this.renderParameterControl(
+        card,
+        descriptor,
+        key,
+        definition,
+        snippetValues[key] ?? definition.default,
+        {
+          cssVarName: definition.cssVar,
+          sourceLabel: snippet ? `${snippet.id}.css` : undefined,
+        },
+      );
     }
   }
 
@@ -91,10 +132,11 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
     key: string,
     definition: ScrippetParameterDefinition,
     value: ScrippetParameterValue,
+    options: ParameterDisplayOptions = {},
   ): void {
     const setting = new Setting(container).setName(definition.label);
     if (definition.description) setting.setDesc(definition.description);
-    this.renderParameterDetails(setting, descriptor, key, definition);
+    this.renderParameterDetails(setting, definition, options);
 
     if (definition.type === "boolean") {
       setting.addToggle((toggle) =>
@@ -202,9 +244,8 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
 
   private renderParameterDetails(
     setting: Setting,
-    descriptor: ScrippetDescriptor,
-    key: string,
     definition: ScrippetParameterDefinition,
+    options: ParameterDisplayOptions,
   ): void {
     const details = setting.descEl.createDiv({ cls: "scrippet-parameter-details" });
     details.createSpan({
@@ -212,11 +253,17 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
       text: `Default: ${this.formatParameterValue(definition, definition.default)}`,
     });
 
-    const cssVar = resolveScrippetParameterCssVarName(descriptor.id, key, definition);
-    if (cssVar) {
+    if (options.sourceLabel) {
+      details.createSpan({
+        cls: "scrippet-parameter-source",
+        text: `Source: ${options.sourceLabel}`,
+      });
+    }
+
+    if (options.cssVarName) {
       const cssDetail = details.createSpan({ cls: "scrippet-parameter-css-var" });
       cssDetail.createSpan({ text: "CSS: " });
-      cssDetail.createEl("code", { text: cssVar });
+      cssDetail.createEl("code", { text: options.cssVarName });
     }
   }
 
@@ -278,8 +325,24 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
   private getParameterizedDescriptors(): ScrippetDescriptor[] {
     const { commands, startup } = this.scrippetPlugin.manager.scan;
     return [...commands, ...startup]
-      .filter((descriptor) => Boolean(descriptor.metadata.settings))
+      .filter((descriptor) => {
+        const snippet = this.getCssSnippetSource(descriptor);
+        return Boolean(descriptor.metadata.settings || snippet?.settings || snippet?.error);
+      })
       .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  private getCssSnippetSource(descriptor: ScrippetDescriptor): CssSnippetParameterSource | undefined {
+    const snippetId = this.getRequiredSnippetId(descriptor);
+    return snippetId ? this.scrippetPlugin.snippetParameters.get(snippetId) : undefined;
+  }
+
+  private getRequiredSnippetId(descriptor: ScrippetDescriptor): string | undefined {
+    try {
+      return getRequiredSnippetId(descriptor.metadata);
+    } catch {
+      return undefined;
+    }
   }
 
   private hasSavedValues(id: string): boolean {
@@ -291,6 +354,7 @@ export class ParameterizedScrippetSettingTab extends ScrippetSettingTab {
     this.scrippetPlugin.parameterCss.sync(
       [...commands, ...startup],
       this.scrippetPlugin.settings.scrippetSettings,
+      (id) => this.scrippetPlugin.snippetParameters.get(id),
     );
   }
 

--- a/tests/css-snippet-parameters.test.ts
+++ b/tests/css-snippet-parameters.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  parseCssSnippetParameterSchema,
+  resolveCssSnippetRuntimeValues,
+} from "../src/css-snippet-parameters.ts";
+
+test("parses numeric parameters from annotated CSS custom properties", () => {
+  const schema = parseCssSnippetParameterSchema(
+    `
+:root {
+  /*
+   * @scrippets-setting
+   * label: Edge fade width
+   * description: Width of the continuation fade.
+   * min: 0px
+   * max: 100px
+   * step: 1px
+   * control: slider
+   */
+  --scrippets-nowrap-fade-width: 32px;
+}
+`,
+    "nowrap",
+  );
+
+  assert.ok(schema);
+  assert.deepEqual(Object.keys(schema), ["fade-width"]);
+  assert.equal(schema["fade-width"].type, "number");
+  assert.equal(schema["fade-width"].label, "Edge fade width");
+  assert.equal(schema["fade-width"].description, "Width of the continuation fade.");
+  assert.equal(schema["fade-width"].default, 32);
+  assert.equal(schema["fade-width"].unit, "px");
+  assert.equal(schema["fade-width"].min, 0);
+  assert.equal(schema["fade-width"].max, 100);
+  assert.equal(schema["fade-width"].step, 1);
+  assert.equal(schema["fade-width"].control, "slider");
+  assert.equal(schema["fade-width"].cssVar, "--scrippets-nowrap-fade-width");
+  assert.equal(schema["fade-width"].runtimeKey, undefined);
+});
+
+test("infers labels and string defaults", () => {
+  const schema = parseCssSnippetParameterSchema(
+    `
+/*
+@scrippets-setting
+*/
+--scrippets-theme-mode: compact;
+`,
+    "theme",
+  );
+
+  assert.ok(schema);
+  assert.equal(schema.mode.type, "string");
+  assert.equal(schema.mode.label, "Mode");
+  assert.equal(schema.mode.default, "compact");
+  assert.equal(schema.mode.cssVar, "--scrippets-theme-mode");
+});
+
+test("key exposes a CSS snippet parameter to invoke settings", () => {
+  const schema = parseCssSnippetParameterSchema(
+    `
+/*
+@scrippets-setting
+key: fade-width
+min: 0px
+max: 100px
+*/
+--scrippets-nowrap-edge-width: 32px;
+`,
+    "nowrap",
+  );
+
+  assert.ok(schema);
+  assert.equal(schema["fade-width"].runtimeKey, "fade-width");
+  assert.deepEqual(resolveCssSnippetRuntimeValues(schema, undefined), {
+    "fade-width": 32,
+  });
+  assert.deepEqual(resolveCssSnippetRuntimeValues(schema, { "fade-width": 55 }), {
+    "fade-width": 55,
+  });
+});
+
+test("CSS snippet bounds may omit a unit when the declaration supplies it", () => {
+  const schema = parseCssSnippetParameterSchema(
+    `
+/*
+@scrippets-setting
+min: 0
+max: 40
+step: 1
+*/
+--scrippets-nowrap-scrollbar-offset: 12px;
+`,
+    "nowrap",
+  );
+
+  assert.ok(schema);
+  assert.equal(schema["scrollbar-offset"].min, 0);
+  assert.equal(schema["scrollbar-offset"].max, 40);
+  assert.equal(schema["scrollbar-offset"].step, 1);
+  assert.equal(schema["scrollbar-offset"].unit, "px");
+});
+
+test("rejects incompatible units and invalid annotation fields", () => {
+  assert.throws(
+    () =>
+      parseCssSnippetParameterSchema(
+        `
+/*
+@scrippets-setting
+min: 0rem
+max: 100rem
+*/
+--scrippets-nowrap-fade-width: 32px;
+`,
+        "nowrap",
+      ),
+    /uses unit "rem" but the custom property uses "px"/,
+  );
+
+  assert.throws(
+    () =>
+      parseCssSnippetParameterSchema(
+        `
+/*
+@scrippets-setting
+maximum: 100px
+*/
+--scrippets-nowrap-fade-width: 32px;
+`,
+        "nowrap",
+      ),
+    /unknown metadata field "maximum"/,
+  );
+});
+
+test("rejects duplicate inferred setting keys", () => {
+  assert.throws(
+    () =>
+      parseCssSnippetParameterSchema(
+        `
+/* @scrippets-setting */
+--scrippets-nowrap-fade-width: 32px;
+/* @scrippets-setting */
+--scrippets-fade-width: 40px;
+`,
+        "nowrap",
+      ),
+    /duplicate setting key "fade-width"/,
+  );
+});


### PR DESCRIPTION
## Summary
- Add `@scrippets-setting` annotations directly in required CSS snippets so visual parameters live beside the custom properties and styles they control.
- Infer parameter type, default value, and unit from the custom-property declaration itself; support optional `label`, `description`, `min`, `max`, `step`, and `control` metadata.
- Derive stable setting keys from the snippet id and `--scrippets-*` variable name, preserving existing saved Toggle Wrap values when moving `fade-width` and `scrollbar-offset` out of JavaScript metadata.
- Add optional `key` metadata to expose a CSS-owned parameter to `invoke(plugin, settings)`; without `key`, the parameter remains CSS-only.
- Scan and watch `<vault config dir>/snippets/*.css` through Obsidian vault APIs and refresh parameter metadata when snippets change.
- Render CSS-owned settings in the existing Scrippet parameters card with their CSS source file, custom-property name, sliders/number inputs, and reset actions.
- Apply only saved CSS-owned overrides as inline custom properties. Reset removes the inline override so the declaration in the CSS snippet remains the source of the default.
- Keep existing JavaScript-owned `@settings` and `css-var` behavior compatible.
- Move the Toggle Wrap fade width and scrollbar clearance declarations into `examples/nowrap.css`; `cursor-margin` remains JavaScript-owned.
- Add CSS snippet parameter parser/runtime tests and update README/CHANGELOG.

## Syntax
```css
:root {
  /*
   * @scrippets-setting
   * label: Edge fade width
   * description: Width of the continuation fade at the right edge.
   * min: 0px
   * max: 100px
   * step: 1px
   * control: slider
   */
  --scrippets-nowrap-fade-width: 32px;
}
```

The declaration supplies the default and unit. `key: fade-width` can be added when the same value should also be passed to JavaScript as `settings["fade-width"]`.

## Validation
- `node --check` passed for the updated `examples/toggle_nowrap.js`.
- Focused strict TypeScript checks passed for the CSS snippet parser/catalog, CSS override registry, and scrippet loader against minimal Obsidian API stubs.
- Focused runtime checks passed for numeric/string parsing, unit validation, optional runtime keys, and reset behavior (removing the saved override restores CSS ownership of the default).
- Full `npm run check` and `npm run build` could not be run in this environment because repository/package network access is unavailable.

## Manual verification recommended
- Install the branch build, open Settings → Scrippets, and confirm Toggle Wrap shows cursor margin plus the two parameters declared by `nowrap.css`.
- Drag the fade/clearance sliders and confirm the snippet updates live.
- Reset either CSS-owned parameter and confirm its inline custom-property override is removed and the CSS declaration value becomes active.
- Edit an annotated declaration/default in `nowrap.css` and confirm the settings panel refreshes after the vault change event.